### PR TITLE
Namespace attributes with xee

### DIFF
--- a/examples/basic_example.rs
+++ b/examples/basic_example.rs
@@ -1,60 +1,60 @@
 use xee_extract::{Extractor, Extract};
 
 #[derive(Extract, Debug)]
-//#[xpath(ns(
+//#[xee(xpath(ns(
 //    atom = "http://www.w3.org/2005/Atom",
 //    nlm = "https://id.nlm.nih.gov/datmm/",
 //    meta = "http://example.org/Meta"
-//))]
-//#[xpath(var(
+//)))]
+//#[xee(xpath(var(
 //    baseurl = "if ($env = 'production') then 'https://prod.api.org' else 'https://dev.api.org'",
 //    short_id = "tokenize(atom:id, ':')[last()]"
-//))]
+//)))]
 struct Entry {
-    #[xpath("atom:id/text()")]
+    #[xee(xpath("atom:id/text()"))]
     id: String,
 
-    #[xpath("$short_id")]
+    #[xee(xpath("$short_id"))]
     short_id: String,
 
-    #[xpath("if (exists(atom:subtitle)) then atom:subtitle else atom:title")]
+    #[xee(xpath("if (exists(atom:subtitle)) then atom:subtitle else atom:title"))]
     title: String,
 
-    #[extract("atom:author")]
+    #[xee(extract("atom:author"))]
     authors: Vec<Author>,
 
-    #[xpath("concat($baseurl, '/entry/', $short_id)")]
+    #[xee(xpath("concat($baseurl, '/entry/', $short_id)"))]
     url: Option<String>,
 
-    #[extract("//nlm:article-meta")]
+    #[xee(extract("//nlm:article-meta"))]
     metadata: Metadata,
 
-    #[xpath("atom:category/@term")]
+    #[xee(xpath("atom:category/@term"))]
     category: Option<String>,
 }
 
 #[derive(Extract, Debug)]
-//#[xpath(ns(atom = "http://www.w3.org/2005/Atom"))]
+//#[xee(xpath(ns(atom = "http://www.w3.org/2005/Atom")))]
 struct Author {
-    #[xpath("atom:name/text()")]
+    #[xee(xpath("atom:name/text()"))]
     name: String,
 
-    #[xpath("atom:uri/text()")]
+    #[xee(xpath("atom:uri/text()"))]
     homepage: Option<String>,
 }
 
 #[derive(Extract, Debug)]
-//#[xpath(ns(
+//#[xee(xpath(ns(
 //    nlm = "https://id.nlm.nih.gov/datmm/",
-//))]
+//)))]
 struct Metadata {
-    #[xpath("nlm:fpage/text()")]
+    #[xee(xpath("nlm:fpage/text()"))]
     first_page: Option<String>,
 
-    #[xpath("nlm:lpage/text()")]
+    #[xee(xpath("nlm:lpage/text()"))]
     last_page: Option<String>,
 
-    #[xpath("nlm:pub-id[@pub-id-type='doi'][1]/text()")]
+    #[xee(xpath("nlm:pub-id[@pub-id-type='doi'][1]/text()"))]
     doi: Option<String>,
 }
 

--- a/examples/combined_namespace_example.rs
+++ b/examples/combined_namespace_example.rs
@@ -1,35 +1,35 @@
 use xee_extract::{Extractor, Extract};
 
 #[derive(Extract, Debug, PartialEq)]
-#[default_ns("http://www.w3.org/2005/Atom")]
-#[ns(
+#[xee(default_ns("http://www.w3.org/2005/Atom"))]
+#[xee(ns(
     dc = "http://purl.org/dc/elements/1.1/"
-)]
-#[context("(//entry)[1]")]
+))]
+#[xee(context("(//entry)[1]"))]
 struct Entry {
-    #[xpath("id/text()")]
+    #[xee(xpath("id/text()"))]
     id: String,
 
-    #[xpath("title/text()")]
+    #[xee(xpath("title/text()"))]
     title: String,
 
-    #[xpath("dc:creator/text()")]
+    #[xee(xpath("dc:creator/text()"))]
     creator: Option<String>,
 
-    #[extract("author")]
+    #[xee(extract("author"))]
     author: Author,
 }
 
 #[derive(Extract, Debug, PartialEq)]
-#[default_ns("http://www.w3.org/2005/Atom")]
-#[ns(
+#[xee(default_ns("http://www.w3.org/2005/Atom"))]
+#[xee(ns(
     dc = "http://purl.org/dc/elements/1.1/"
-)]
+))]
 struct Author {
-    #[xpath("name/text()")]
+    #[xee(xpath("name/text()"))]
     name: String,
 
-    #[xpath("dc:email/text()")]
+    #[xee(xpath("dc:email/text()"))]
     email: Option<String>,
 }
 

--- a/examples/default_namespace_example.rs
+++ b/examples/default_namespace_example.rs
@@ -1,29 +1,29 @@
 use xee_extract::{Extractor, Extract};
 
 #[derive(Extract, Debug, PartialEq)]
-#[default_ns("http://www.w3.org/2005/Atom")]
-#[context("(//entry)[1]")]
+#[xee(default_ns("http://www.w3.org/2005/Atom"))]
+#[xee(context("(//entry)[1]"))]
 struct Entry {
-    #[xpath("id/text()")]
+    #[xee(xpath("id/text()"))]
     id: String,
 
-    #[xpath("title/text()")]
+    #[xee(xpath("title/text()"))]
     title: String,
 
-    #[xpath("category/@term")]
+    #[xee(xpath("category/@term"))]
     category: Option<String>,
 
-    #[extract("author")]
+    #[xee(extract("author"))]
     author: Author,
 }
 
 #[derive(Extract, Debug, PartialEq)]
-#[default_ns("http://www.w3.org/2005/Atom")]
+#[xee(default_ns("http://www.w3.org/2005/Atom"))]
 struct Author {
-    #[xpath("name/text()")]
+    #[xee(xpath("name/text()"))]
     name: String,
 
-    #[xpath("email/text()")]
+    #[xee(xpath("email/text()"))]
     email: Option<String>,
 }
 

--- a/examples/namespace_context_example.rs
+++ b/examples/namespace_context_example.rs
@@ -1,37 +1,37 @@
 use xee_extract::{Extractor, Extract};
 
 #[derive(Extract, Debug, PartialEq)]
-#[ns(
+#[xee(ns(
     atom = "http://www.w3.org/2005/Atom",
     nlm = "https://id.nlm.nih.gov/datmm/",
     meta = "http://example.org/Meta"
-)]
-#[context("(//entry)[1]")]
+))]
+#[xee(context("(//entry)[1]"))]
 struct Entry {
-    #[xpath("atom:id/text()")]
+    #[xee(xpath("atom:id/text()"))]
     id: String,
 
-    #[xpath("atom:title/text()")]
+    #[xee(xpath("atom:title/text()"))]
     title: String,
 
-    #[xpath("atom:category/@term")]
+    #[xee(xpath("atom:category/@term"))]
     category: Option<String>,
 
-    #[extract("atom:author")]
+    #[xee(extract("atom:author"))]
     author: Author,
 }
 
 #[derive(Extract, Debug, PartialEq)]
-#[ns(
+#[xee(ns(
     atom = "http://www.w3.org/2005/Atom",
     nlm = "https://id.nlm.nih.gov/datmm/",
     meta = "http://example.org/Meta"
-)]
+))]
 struct Author {
-    #[xpath("atom:name/text()")]
+    #[xee(xpath("atom:name/text()"))]
     name: String,
 
-    #[xpath("atom:email/text()")]
+    #[xee(xpath("atom:email/text()"))]
     email: Option<String>,
 }
 

--- a/examples/new_attributes_example.rs
+++ b/examples/new_attributes_example.rs
@@ -2,34 +2,34 @@ use xee_extract::{Extractor, Extract};
 
 #[derive(Extract, Debug, PartialEq)]
 struct Library {
-    #[xpath("//library/@name")]
+    #[xee(xpath("//library/@name"))]
     name: String,
 
-    #[extract("//library/books/book")]
+    #[xee(extract("//library/books/book"))]
     books: Vec<Book>,
 }
 
 #[derive(Extract, Debug, PartialEq)]
 struct Book {
-    #[xpath("title/text()")]
+    #[xee(xpath("title/text()"))]
     title: String,
 
-    #[xpath("author/text()")]
+    #[xee(xpath("author/text()"))]
     author: String,
 
-    #[xpath("year/text()")]
+    #[xee(xpath("year/text()"))]
     year: Option<i32>,
 
-    #[xpath("genre/text()")]
+    #[xee(xpath("genre/text()"))]
     genres: Vec<String>,
 }
 
 #[derive(Extract, Debug, PartialEq)]
 struct SimpleBook {
-    #[xpath("title/text()")]
+    #[xee(xpath("title/text()"))]
     title: String,
 
-    #[xpath("author/text()")]
+    #[xee(xpath("author/text()"))]
     author: String,
 }
 

--- a/examples/pretty_errors_example.rs
+++ b/examples/pretty_errors_example.rs
@@ -2,16 +2,16 @@ use xee_extract::{Extractor, Extract, ExtractError};
 
 #[derive(Extract, Debug)]
 struct Book {
-    #[xpath("title/text()")]
+    #[xee(xpath("title/text()"))]
     title: String,
 
-    #[xpath("author/text()")]
+    #[xee(xpath("author/text()"))]
     author: String,
 
-    #[xpath("year/text()")]
+    #[xee(xpath("year/text()"))]
     year: Option<String>,
 
-    #[xpath("genre/text()")]
+    #[xee(xpath("genre/text()"))]
     genres: Vec<String>,
 }
 
@@ -84,11 +84,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\n4. Error with invalid XPath expression:");
     #[derive(Extract, Debug)]
     struct InvalidXPathBook {
-        #[xpath("title/text()")]
+        #[xee(xpath("title/text()"))]
         _title: String,
         
         // This XPath is invalid
-        #[xpath("invalid xpath [")]
+        #[xee(xpath("invalid xpath ["))]
         _invalid: String,
     }
 

--- a/examples/simple_example.rs
+++ b/examples/simple_example.rs
@@ -2,25 +2,25 @@ use xee_extract::{Extractor, Extract};
 
 #[derive(Extract, Debug, PartialEq)]
 struct SimpleEntry {
-    #[xpath("//id/text()")]
+    #[xee(xpath("//id/text()"))]
     id: String,
 
-    #[xpath("//title/text()")]
+    #[xee(xpath("//title/text()"))]
     title: String,
 
-    #[xpath("//category/@term")]
+    #[xee(xpath("//category/@term"))]
     category: Option<String>,
 
-    #[extract("//author")]
+    #[xee(extract("//author"))]
     author: Author,
 }
 
 #[derive(Extract, Debug, PartialEq)]
 struct Author {
-    #[xpath("name/text()")]
+    #[xee(xpath("name/text()"))]
     name: String,
 
-    #[xpath("email/text()")]
+    #[xee(xpath("email/text()"))]
     email: Option<String>,
 }
 

--- a/examples/simple_pretty_errors.rs
+++ b/examples/simple_pretty_errors.rs
@@ -2,13 +2,13 @@ use xee_extract::{Extractor, Extract, ExtractError};
 
 #[derive(Extract, Debug)]
 struct SimpleBook {
-    #[xpath("//title/text()")]
+    #[xee(xpath("//title/text()"))]
     title: String,
 
-    #[xpath("//author/text()")]
+    #[xee(xpath("//author/text()"))]
     author: String,
 
-    #[xpath("//year/text()")]
+    #[xee(xpath("//year/text()"))]
     year: Option<String>,
 }
 

--- a/tests/basic_extraction.rs
+++ b/tests/basic_extraction.rs
@@ -2,43 +2,43 @@ use xee_extract::{Extractor, Extract};
 
 #[derive(Extract, Debug, PartialEq)]
 struct SimpleStruct {
-    #[xpath("//id/text()")]
+    #[xee(xpath("//id/text()"))]
     id: String,
 
-    #[xpath("//title/text()")]
+    #[xee(xpath("//title/text()"))]
     title: String,
 
-    #[xpath("//category/@term")]
+    #[xee(xpath("//category/@term"))]
     category: Option<String>,
 }
 
 #[derive(Extract, Debug, PartialEq)]
 struct ComplexStruct {
-    #[xpath("//id/text()")]
+    #[xee(xpath("//id/text()"))]
     id: String,
 
-    #[xpath("//title/text()")]
+    #[xee(xpath("//title/text()"))]
     title: String,
 
-    #[xpath("//subtitle/text()")]
+    #[xee(xpath("//subtitle/text()"))]
     subtitle: Option<String>,
 
-    #[xpath("//category/@term")]
+    #[xee(xpath("//category/@term"))]
     category: Option<String>,
 
-    #[xpath("//tags/tag/text()")]
+    #[xee(xpath("//tags/tag/text()"))]
     tags: Vec<String>,
 }
 
 #[derive(Extract, Debug, PartialEq)]
 struct NestedStruct {
-    #[xpath("//id/text()")]
+    #[xee(xpath("//id/text()"))]
     id: String,
 
-    #[xpath("//author/name/text()")]
+    #[xee(xpath("//author/name/text()"))]
     author_name: String,
 
-    #[xpath("//author/email/text()")]
+    #[xee(xpath("//author/email/text()"))]
     author_email: Option<String>,
 }
 

--- a/tests/binary_extraction.rs
+++ b/tests/binary_extraction.rs
@@ -1,28 +1,28 @@
 use xee_extract::{Extractor, Extract};
 
 #[derive(Extract, Debug, PartialEq)]
-#[xpath(ns(xs = "http://www.w3.org/2001/XMLSchema"))]
+#[xee(xpath(ns(xs = "http://www.w3.org/2001/XMLSchema")))]
 struct BinaryData {
-    #[xpath("string(//binary-data/text()) cast as xs:base64Binary")]
+    #[xee(xpath("string(//binary-data/text()) cast as xs:base64Binary"))]
     base64_data: Vec<u8>,
 
-    #[xpath("string(//hex-data/text()) cast as xs:hexBinary")]
+    #[xee(xpath("string(//hex-data/text()) cast as xs:hexBinary"))]
     hex_data: Vec<u8>,
 
-    #[xpath("string(//binary-node/text()) cast as xs:base64Binary")]
+    #[xee(xpath("string(//binary-node/text()) cast as xs:base64Binary"))]
     binary_node: Vec<u8>,
 
-    #[xpath("string(//binary-node/text()) cast as xs:base64Binary")]
+    #[xee(xpath("string(//binary-node/text()) cast as xs:base64Binary"))]
     binary_xml: Vec<u8>,
 }
 
 #[derive(Extract, Debug, PartialEq)]
-#[xpath(ns(xs = "http://www.w3.org/2001/XMLSchema"))]
+#[xee(xpath(ns(xs = "http://www.w3.org/2001/XMLSchema")))]
 struct BinaryWithOption {
-    #[xpath("string(//optional-binary/text()) cast as xs:base64Binary")]
+    #[xee(xpath("string(//optional-binary/text()) cast as xs:base64Binary"))]
     optional_binary: Option<Vec<u8>>,
 
-    #[xpath("string(//required-binary/text()) cast as xs:hexBinary")]
+    #[xee(xpath("string(//required-binary/text()) cast as xs:hexBinary"))]
     required_binary: Vec<u8>,
 }
 

--- a/tests/complex_scenarios.rs
+++ b/tests/complex_scenarios.rs
@@ -1,99 +1,99 @@
 use xee_extract::{Extractor, Extract};
 
 #[derive(Extract, Debug, PartialEq)]
-#[context("if (self::book) then . else /book")]
+#[xee(context("if (self::book) then . else /book"))]
 struct Book {
-    #[xpath("@id")]
+    #[xee(xpath("@id"))]
     id: String,
 
-    #[xpath("title/text()")]
+    #[xee(xpath("title/text()"))]
     title: String,
 
-    #[xpath("author/text()")]
+    #[xee(xpath("author/text()"))]
     author: String,
 
-    #[xpath("price/text()")]
+    #[xee(xpath("price/text()"))]
     price: f64,
 
-    #[xpath("@genre")]
+    #[xee(xpath("@genre"))]
     genre: Option<String>,
 
-    #[xpath("tags/tag/text()")]
+    #[xee(xpath("tags/tag/text()"))]
     tags: Vec<String>,
 
-    #[extract("metadata")]
+    #[xee(extract("metadata"))]
     metadata: BookMetadata,
 }
 
 #[derive(Extract, Debug, PartialEq)]
 struct BookMetadata {
-    #[xpath("isbn/text()")]
+    #[xee(xpath("isbn/text()"))]
     isbn: String,
 
-    #[xpath("publisher/text()")]
+    #[xee(xpath("publisher/text()"))]
     publisher: Option<String>,
 
-    #[xpath("publication_date/text()")]
+    #[xee(xpath("publication_date/text()"))]
     publication_date: Option<String>,
 
-    #[xpath("reviews/text()")]
+    #[xee(xpath("reviews/text()"))]
     reviews: Option<String>,
 }
 
 #[derive(Extract, Debug, PartialEq)]
 struct LibraryWithComplexBooks {
-    #[xpath("//library/@name")]
+    #[xee(xpath("//library/@name"))]
     name: String,
 
-    #[xpath("//library/@location")]
+    #[xee(xpath("//library/@location"))]
     location: Option<String>,
 
-    #[extract("//library/books/book")]
+    #[xee(extract("//library/books/book"))]
     books: Vec<Book>,
 }
 
 #[derive(Extract, Debug, PartialEq)]
 struct CompanyWithDepartments {
-    #[xpath("//company/@id")]
+    #[xee(xpath("//company/@id"))]
     id: String,
 
-    #[xpath("//company/name/text()")]
+    #[xee(xpath("//company/name/text()"))]
     name: String,
 
-    #[extract("//company/departments/department")]
+    #[xee(extract("//company/departments/department"))]
     departments: Vec<Department>,
 }
 
 #[derive(Extract, Debug, PartialEq)]
 struct Department {
-    #[xpath("@id")]
+    #[xee(xpath("@id"))]
     id: String,
 
-    #[xpath("name/text()")]
+    #[xee(xpath("name/text()"))]
     name: String,
 
-    #[xpath("manager/name/text()")]
+    #[xee(xpath("manager/name/text()"))]
     manager_name: String,
 
-    #[xpath("manager/email/text()")]
+    #[xee(xpath("manager/email/text()"))]
     manager_email: Option<String>,
 
-    #[xpath("employees/employee/name/text()")]
+    #[xee(xpath("employees/employee/name/text()"))]
     employee_names: Vec<String>,
 }
 
 #[derive(Extract, Debug, PartialEq)]
 struct ConfigStruct {
-    #[xpath("//config/api/base_url/text()")]
+    #[xee(xpath("//config/api/base_url/text()"))]
     base_url: String,
 
-    #[xpath("//config/api/version/text()")]
+    #[xee(xpath("//config/api/version/text()"))]
     version: String,
 
-    #[xpath("//config/user/id/text()")]
+    #[xee(xpath("//config/user/id/text()"))]
     user_id: String,
 
-    #[xpath("//config/user/name/text()")]
+    #[xee(xpath("//config/user/name/text()"))]
     user_name: String,
 }
 

--- a/tests/context.rs
+++ b/tests/context.rs
@@ -2,38 +2,38 @@ use xee_extract::{Extractor, Extract};
 
 // Test 1: Context only
 #[derive(Extract, Debug, PartialEq)]
-#[context("(//entry)[1]")]
+#[xee(context("(//entry)[1]"))]
 struct ContextOnly {
-    #[xpath("@id")]
+    #[xee(xpath("@id"))]
     id: String,
 
-    #[xpath("title/text()")]
+    #[xee(xpath("title/text()"))]
     title: String,
 
-    #[xpath("author/name/text()")]
+    #[xee(xpath("author/name/text()"))]
     author_name: String,
 }
 
 // Test 2: Context with conditional logic
 #[derive(Extract, Debug, PartialEq)]
-#[context("if (self::book) then . else /book")]
+#[xee(context("if (self::book) then . else /book"))]
 struct Book {
-    #[xpath("@id")]
+    #[xee(xpath("@id"))]
     id: String,
 
-    #[xpath("title/text()")]
+    #[xee(xpath("title/text()"))]
     title: String,
 
-    #[xpath("author/text()")]
+    #[xee(xpath("author/text()"))]
     author: String,
 
-    #[xpath("price/text()")]
+    #[xee(xpath("price/text()"))]
     price: f64,
 
-    #[xpath("@genre")]
+    #[xee(xpath("@genre"))]
     genre: Option<String>,
 
-    #[xpath("tags/tag/text()")]
+    #[xee(xpath("tags/tag/text()"))]
     tags: Vec<String>,
 }
 

--- a/tests/error_handling.rs
+++ b/tests/error_handling.rs
@@ -2,49 +2,49 @@ use xee_extract::{Extractor, Extract, ExtractError};
 
 #[derive(Extract, Debug, PartialEq)]
 struct SimpleStruct {
-    #[xpath("//id/text()")]
+    #[xee(xpath("//id/text()"))]
     id: String,
 
-    #[xpath("//title/text()")]
+    #[xee(xpath("//title/text()"))]
     title: String,
 
-    #[xpath("//category/@term")]
+    #[xee(xpath("//category/@term"))]
     category: Option<String>,
 }
 
 #[derive(Extract, Debug, PartialEq)]
 struct Book {
-    #[xpath("title/text()")]
+    #[xee(xpath("title/text()"))]
     title: String,
 
-    #[xpath("author/text()")]
+    #[xee(xpath("author/text()"))]
     author: String,
 
-    #[xpath("year/text()")]
+    #[xee(xpath("year/text()"))]
     year: Option<i32>,
 
-    #[xpath("genre/text()")]
+    #[xee(xpath("genre/text()"))]
     genres: Vec<String>,
 }
 
 #[derive(Extract, Debug, PartialEq)]
 struct SimpleStructWithNested {
-    #[xpath("//id/text()")]
+    #[xee(xpath("//id/text()"))]
     id: String,
 
-    #[xpath("//title/text()")]
+    #[xee(xpath("//title/text()"))]
     title: String,
 
-    #[extract("//nested")]
+    #[xee(extract("//nested"))]
     nested: NestedStruct,
 }
 
 #[derive(Extract, Debug, PartialEq)]
 struct NestedStruct {
-    #[xpath("value/text()")]
+    #[xee(xpath("value/text()"))]
     value: String,
 
-    #[xpath("optional/text()")]
+    #[xee(xpath("optional/text()"))]
     optional: Option<String>,
 }
 

--- a/tests/namespaces.rs
+++ b/tests/namespaces.rs
@@ -2,152 +2,152 @@ use xee_extract::{Extractor, Extract};
 
 // Test 1: Basic namespace prefixes only
 #[derive(Extract, Debug, PartialEq)]
-#[ns(
+#[xee(ns(
     atom = "http://www.w3.org/2005/Atom",
     dc = "http://purl.org/dc/elements/1.1/"
-)]
-#[context("(//entry)[1]")]
+))]
+#[xee(context("(//entry)[1]"))]
 struct NamespaceOnly {
-    #[xpath("atom:id/text()")]
+    #[xee(xpath("atom:id/text()"))]
     id: String,
 
-    #[xpath("atom:title/text()")]
+    #[xee(xpath("atom:title/text()"))]
     title: String,
 
-    #[xpath("dc:creator/text()")]
+    #[xee(xpath("dc:creator/text()"))]
     creator: Option<String>,
 }
 
 // Test 2: Default namespace only
 #[derive(Extract, Debug, PartialEq)]
-#[default_ns("http://www.w3.org/2005/Atom")]
-#[context("(//entry)[1]")]
+#[xee(default_ns("http://www.w3.org/2005/Atom"))]
+#[xee(context("(//entry)[1]"))]
 struct DefaultNamespaceOnly {
-    #[xpath("id/text()")]
+    #[xee(xpath("id/text()"))]
     id: String,
 
-    #[xpath("title/text()")]
+    #[xee(xpath("title/text()"))]
     title: String,
 
-    #[xpath("author/name/text()")]
+    #[xee(xpath("author/name/text()"))]
     author_name: String,
 }
 
 // Test 3: Namespace prefixes + Context
 #[derive(Extract, Debug, PartialEq)]
-#[ns(
+#[xee(ns(
     atom = "http://www.w3.org/2005/Atom",
     dc = "http://purl.org/dc/elements/1.1/"
-)]
-#[context("(//entry)[1]")]
+))]
+#[xee(context("(//entry)[1]"))]
 struct NamespaceAndContext {
-    #[xpath("atom:id/text()")]
+    #[xee(xpath("atom:id/text()"))]
     id: String,
 
-    #[xpath("atom:title/text()")]
+    #[xee(xpath("atom:title/text()"))]
     title: String,
 
-    #[xpath("dc:creator/text()")]
+    #[xee(xpath("dc:creator/text()"))]
     creator: Option<String>,
 }
 
 // Test 4: Default namespace + Context
 #[derive(Extract, Debug, PartialEq)]
-#[default_ns("http://www.w3.org/2005/Atom")]
-#[context("(//entry)[1]")]
+#[xee(default_ns("http://www.w3.org/2005/Atom"))]
+#[xee(context("(//entry)[1]"))]
 struct DefaultNamespaceAndContext {
-    #[xpath("id/text()")]
+    #[xee(xpath("id/text()"))]
     id: String,
 
-    #[xpath("title/text()")]
+    #[xee(xpath("title/text()"))]
     title: String,
 
-    #[xpath("author/name/text()")]
+    #[xee(xpath("author/name/text()"))]
     author_name: String,
 }
 
 // Test 5: Default namespace + Namespace prefixes
 #[derive(Extract, Debug, PartialEq)]
-#[default_ns("http://www.w3.org/2005/Atom")]
-#[ns(
+#[xee(default_ns("http://www.w3.org/2005/Atom"))]
+#[xee(ns(
     dc = "http://purl.org/dc/elements/1.1/"
-)]
-#[context("(//entry)[1]")]
+))]
+#[xee(context("(//entry)[1]"))]
 struct DefaultAndPrefixedNamespaces {
-    #[xpath("id/text()")]
+    #[xee(xpath("id/text()"))]
     id: String,
 
-    #[xpath("title/text()")]
+    #[xee(xpath("title/text()"))]
     title: String,
 
-    #[xpath("dc:creator/text()")]
+    #[xee(xpath("dc:creator/text()"))]
     creator: Option<String>,
 }
 
 // Test 6: All three combined
 #[derive(Extract, Debug, PartialEq)]
-#[default_ns("http://www.w3.org/2005/Atom")]
-#[ns(
+#[xee(default_ns("http://www.w3.org/2005/Atom"))]
+#[xee(ns(
     dc = "http://purl.org/dc/elements/1.1/"
-)]
-#[context("(//entry)[1]")]
+))]
+#[xee(context("(//entry)[1]"))]
 struct AllCombined {
-    #[xpath("id/text()")]
+    #[xee(xpath("id/text()"))]
     id: String,
 
-    #[xpath("title/text()")]
+    #[xee(xpath("title/text()"))]
     title: String,
 
-    #[xpath("dc:creator/text()")]
+    #[xee(xpath("dc:creator/text()"))]
     creator: Option<String>,
 }
 
 // Test 7: Nested structs with different namespace configurations
 #[derive(Extract, Debug, PartialEq)]
-#[default_ns("http://www.w3.org/2005/Atom")]
-#[ns(
+#[xee(default_ns("http://www.w3.org/2005/Atom"))]
+#[xee(ns(
     dc = "http://purl.org/dc/elements/1.1/"
-)]
-#[context("(//entry)[1]")]
+))]
+#[xee(context("(//entry)[1]"))]
 struct ParentWithNamespaces {
-    #[xpath("id/text()")]
+    #[xee(xpath("id/text()"))]
     id: String,
 
-    #[extract("author")]
+    #[xee(extract("author"))]
     author: ChildWithDifferentNamespaces,
 }
 
 #[derive(Extract, Debug, PartialEq)]
-#[ns(
+#[xee(ns(
     atom = "http://www.w3.org/2005/Atom"
-)]
+))]
 struct ChildWithDifferentNamespaces {
-    #[xpath("atom:name/text()")]
+    #[xee(xpath("atom:name/text()"))]
     name: String,
 
-    #[xpath("atom:email/text()")]
+    #[xee(xpath("atom:email/text()"))]
     email: Option<String>,
 }
 
 // Test 8: Multiple default namespaces in nested structs
 #[derive(Extract, Debug, PartialEq)]
-#[default_ns("http://www.w3.org/2005/Atom")]
-#[context("(//entry)[1]")]
+#[xee(default_ns("http://www.w3.org/2005/Atom"))]
+#[xee(context("(//entry)[1]"))]
 struct ParentWithDefaultNamespace {
-    #[xpath("id/text()")]
+    #[xee(xpath("id/text()"))]
     id: String,
 
-    #[extract("author")]
+    #[xee(extract("author"))]
     author: ChildWithDefaultNamespace,
 }
 
 #[derive(Extract, Debug, PartialEq)]
-#[default_ns("http://www.w3.org/2005/Atom")]
+#[xee(default_ns("http://www.w3.org/2005/Atom"))]
 struct ChildWithDefaultNamespace {
-    #[xpath("name/text()")]
+    #[xee(xpath("name/text()"))]
     name: String,
 
-    #[xpath("email/text()")]
+    #[xee(xpath("email/text()"))]
     email: Option<String>,
 }
 

--- a/tests/nested_structs.rs
+++ b/tests/nested_structs.rs
@@ -1,87 +1,87 @@
 use xee_extract::{Extractor, Extract};
 
 #[derive(Extract, Debug, PartialEq)]
-#[context("if (self::book) then . else /book")]
+#[xee(context("if (self::book) then . else /book"))]
 struct Book {
-    #[xpath("@id")]
+    #[xee(xpath("@id"))]
     id: String,
 
-    #[xpath("title/text()")]
+    #[xee(xpath("title/text()"))]
     title: String,
 
-    #[xpath("author/text()")]
+    #[xee(xpath("author/text()"))]
     author: String,
 
-    #[xpath("price/text()")]
+    #[xee(xpath("price/text()"))]
     price: f64,
 
-    #[xpath("@genre")]
+    #[xee(xpath("@genre"))]
     genre: Option<String>,
 
-    #[xpath("tags/tag/text()")]
+    #[xee(xpath("tags/tag/text()"))]
     tags: Vec<String>,
 }
 
 #[derive(Extract, Debug, PartialEq)]
 struct Library {
-    #[xpath("//library/@name")]
+    #[xee(xpath("//library/@name"))]
     name: String,
 
-    #[extract("//library/books/book")]
+    #[xee(extract("//library/books/book"))]
     books: Vec<Book>,
 }
 
 #[derive(Extract, Debug, PartialEq)]
 struct Person {
-    #[xpath("//person/@id")]
+    #[xee(xpath("//person/@id"))]
     id: String,
 
-    #[xpath("//person/name/first/text()")]
+    #[xee(xpath("//person/name/first/text()"))]
     first_name: String,
 
-    #[xpath("//person/name/last/text()")]
+    #[xee(xpath("//person/name/last/text()"))]
     last_name: String,
 
-    #[xpath("//person/email/text()")]
+    #[xee(xpath("//person/email/text()"))]
     email: Option<String>,
 
-    #[xpath("//person/address/street/text()")]
+    #[xee(xpath("//person/address/street/text()"))]
     street: Option<String>,
 
-    #[xpath("//person/address/city/text()")]
+    #[xee(xpath("//person/address/city/text()"))]
     city: Option<String>,
 }
 
 #[derive(Extract, Debug, PartialEq)]
 struct Company {
-    #[xpath("//company/@id")]
+    #[xee(xpath("//company/@id"))]
     id: String,
 
-    #[xpath("//company/name/text()")]
+    #[xee(xpath("//company/name/text()"))]
     name: String,
 
-    #[xpath("//company/employees/person/name/first/text()")]
+    #[xee(xpath("//company/employees/person/name/first/text()"))]
     employee_first_names: Vec<String>,
 }
 
 #[derive(Extract, Debug, PartialEq)]
 struct SimpleStruct {
-    #[xpath("//id/text()")]
+    #[xee(xpath("//id/text()"))]
     id: String,
 
-    #[xpath("//title/text()")]
+    #[xee(xpath("//title/text()"))]
     title: String,
 
-    #[extract("//nested")]
+    #[xee(extract("//nested"))]
     nested: NestedStruct,
 }
 
 #[derive(Extract, Debug, PartialEq)]
 struct NestedStruct {
-    #[xpath("value/text()")]
+    #[xee(xpath("value/text()"))]
     value: String,
 
-    #[xpath("optional/text()")]
+    #[xee(xpath("optional/text()"))]
     optional: Option<String>,
 }
 

--- a/tests/optional_fields.rs
+++ b/tests/optional_fields.rs
@@ -2,58 +2,58 @@ use xee_extract::{Extractor, Extract};
 
 #[derive(Extract, Debug, PartialEq)]
 struct SimpleStruct {
-    #[xpath("//id/text()")]
+    #[xee(xpath("//id/text()"))]
     id: String,
 
-    #[xpath("//title/text()")]
+    #[xee(xpath("//title/text()"))]
     title: String,
 
-    #[xpath("//category/@term")]
+    #[xee(xpath("//category/@term"))]
     category: Option<String>,
 }
 
 #[derive(Extract, Debug, PartialEq)]
 struct ComplexStruct {
-    #[xpath("//id/text()")]
+    #[xee(xpath("//id/text()"))]
     id: String,
 
-    #[xpath("//title/text()")]
+    #[xee(xpath("//title/text()"))]
     title: String,
 
-    #[xpath("//subtitle/text()")]
+    #[xee(xpath("//subtitle/text()"))]
     subtitle: Option<String>,
 
-    #[xpath("//category/@term")]
+    #[xee(xpath("//category/@term"))]
     category: Option<String>,
 
-    #[xpath("//tags/tag/text()")]
+    #[xee(xpath("//tags/tag/text()"))]
     tags: Vec<String>,
 }
 
 #[derive(Extract, Debug, PartialEq)]
 struct NestedStruct {
-    #[xpath("//id/text()")]
+    #[xee(xpath("//id/text()"))]
     id: String,
 
-    #[xpath("//author/name/text()")]
+    #[xee(xpath("//author/name/text()"))]
     author_name: String,
 
-    #[xpath("//author/email/text()")]
+    #[xee(xpath("//author/email/text()"))]
     author_email: Option<String>,
 }
 
 #[derive(Extract, Debug, PartialEq)]
 struct Book {
-    #[xpath("/book/title/text()")]
+    #[xee(xpath("/book/title/text()"))]
     title: String,
 
-    #[xpath("/book/author/text()")]
+    #[xee(xpath("/book/author/text()"))]
     author: String,
 
-    #[xpath("/book/year/text()")]
+    #[xee(xpath("/book/year/text()"))]
     year: Option<i32>,
 
-    #[xpath("/book/genre/text()")]
+    #[xee(xpath("/book/genre/text()"))]
     genres: Vec<String>,
 }
 
@@ -136,22 +136,22 @@ fn test_person_without_optional_fields() {
 
 #[derive(Extract, Debug, PartialEq)]
 struct Person {
-    #[xpath("//person/@id")]
+    #[xee(xpath("//person/@id"))]
     id: String,
 
-    #[xpath("//person/name/first/text()")]
+    #[xee(xpath("//person/name/first/text()"))]
     first_name: String,
 
-    #[xpath("//person/name/last/text()")]
+    #[xee(xpath("//person/name/last/text()"))]
     last_name: String,
 
-    #[xpath("//person/email/text()")]
+    #[xee(xpath("//person/email/text()"))]
     email: Option<String>,
 
-    #[xpath("//person/address/street/text()")]
+    #[xee(xpath("//person/address/street/text()"))]
     street: Option<String>,
 
-    #[xpath("//person/address/city/text()")]
+    #[xee(xpath("//person/address/city/text()"))]
     city: Option<String>,
 }
 

--- a/tests/pretty_errors.rs
+++ b/tests/pretty_errors.rs
@@ -2,46 +2,46 @@ use xee_extract::{Extractor, Extract, ExtractError};
 
 #[derive(Extract, Debug)]
 struct SimpleStruct {
-    #[xpath("//id/text()")]
+    #[xee(xpath("//id/text()"))]
     _id: String,
 
-    #[xpath("//title/text()")]
+    #[xee(xpath("//title/text()"))]
     _title: String,
 
-    #[xpath("//category/@term")]
+    #[xee(xpath("//category/@term"))]
     _category: Option<String>,
 }
 
 #[derive(Extract, Debug)]
 struct Book {
-    #[xpath("title/text()")]
+    #[xee(xpath("title/text()"))]
     _title: String,
 
-    #[xpath("author/text()")]
+    #[xee(xpath("author/text()"))]
     _author: String,
 
-    #[xpath("year/text()")]
+    #[xee(xpath("year/text()"))]
     _year: Option<i32>,
 
-    #[xpath("genre/text()")]
+    #[xee(xpath("genre/text()"))]
     _genres: Vec<String>,
 }
 
 #[derive(Extract, Debug)]
 struct ExtractTestStruct {
-    #[extract("author")]
+    #[xee(extract("author"))]
     _author: Author,
 }
 
 #[derive(Extract, Debug)]
 struct Author {
-    #[xpath("name/text()")]
+    #[xee(xpath("name/text()"))]
     _name: String,
 }
 
 #[derive(Extract, Debug)]
 struct XmlTestStruct {
-    #[xml("author")]
+    #[xee(xml("author"))]
     _author_xml: String,
 }
 
@@ -80,11 +80,11 @@ fn test_pretty_error_invalid_xpath() {
     // Create a struct with an invalid XPath expression
     #[derive(Extract, Debug)]
     struct InvalidXPathStruct {
-        #[xpath("//id/text()")]
+        #[xee(xpath("//id/text()"))]
         _id: String,
         
         // This XPath is invalid - it will cause a parsing error
-        #[xpath("invalid xpath expression [")]
+        #[xee(xpath("invalid xpath expression ["))]
         _invalid: String,
     }
 
@@ -175,7 +175,7 @@ fn test_application_error_value_extraction() {
     // but the value extraction fails when trying to parse "not_a_number" as an integer
     #[derive(Extract, Debug)]
     struct ValueTestStruct {
-        #[xpath("//year/text()")]
+        #[xee(xpath("//year/text()"))]
         _year: i32,  // This should fail when trying to parse "not_a_number" as i32
     }
 
@@ -275,9 +275,9 @@ fn test_application_error_namespace() {
 
     // Create a struct that requires a namespace but doesn't have one
     #[derive(Extract, Debug)]
-    #[ns(test = "http://example.com/test")]
+    #[xee(ns(test = "http://example.com/test"))]
     struct NamespaceTestStruct {
-        #[xpath("//test:id/text()")]
+        #[xee(xpath("//test:id/text()"))]
         _id: String,
     }
 

--- a/tests/vectors.rs
+++ b/tests/vectors.rs
@@ -2,55 +2,55 @@ use xee_extract::{Extractor, Extract};
 
 #[derive(Extract, Debug, PartialEq)]
 struct ComplexStruct {
-    #[xpath("//id/text()")]
+    #[xee(xpath("//id/text()"))]
     id: String,
 
-    #[xpath("//title/text()")]
+    #[xee(xpath("//title/text()"))]
     title: String,
 
-    #[xpath("//subtitle/text()")]
+    #[xee(xpath("//subtitle/text()"))]
     subtitle: Option<String>,
 
-    #[xpath("//category/@term")]
+    #[xee(xpath("//category/@term"))]
     category: Option<String>,
 
-    #[xpath("//tags/tag/text()")]
+    #[xee(xpath("//tags/tag/text()"))]
     tags: Vec<String>,
 }
 
 #[derive(Extract, Debug, PartialEq)]
 struct Book {
-    #[xpath("/book/title/text()")]
+    #[xee(xpath("/book/title/text()"))]
     title: String,
 
-    #[xpath("/book/author/text()")]
+    #[xee(xpath("/book/author/text()"))]
     author: String,
 
-    #[xpath("/book/year/text()")]
+    #[xee(xpath("/book/year/text()"))]
     year: Option<i32>,
 
-    #[xpath("/book/genre/text()")]
+    #[xee(xpath("/book/genre/text()"))]
     genres: Vec<String>,
 }
 
 #[derive(Extract, Debug, PartialEq)]
 struct Library {
-    #[xpath("//library/@name")]
+    #[xee(xpath("//library/@name"))]
     name: String,
 
-    #[extract("//library/books/book")]
+    #[xee(extract("//library/books/book"))]
     books: Vec<Book>,
 }
 
 #[derive(Extract, Debug, PartialEq)]
 struct Company {
-    #[xpath("//company/@id")]
+    #[xee(xpath("//company/@id"))]
     id: String,
 
-    #[xpath("//company/name/text()")]
+    #[xee(xpath("//company/name/text()"))]
     name: String,
 
-    #[xpath("//company/employees/person/name/first/text()")]
+    #[xee(xpath("//company/employees/person/name/first/text()"))]
     employee_first_names: Vec<String>,
 }
 

--- a/tests/xml_attributes.rs
+++ b/tests/xml_attributes.rs
@@ -2,43 +2,43 @@ use xee_extract::{Extractor, Extract};
 
 #[derive(Extract, Debug, PartialEq)]
 struct DocumentWithXml {
-    #[xpath("//id/text()")]
+    #[xee(xpath("//id/text()"))]
     id: String,
 
-    #[xpath("//title/text()")]
+    #[xee(xpath("//title/text()"))]
     title: String,
 
-    #[xml("//content")]
+    #[xee(xml("//content"))]
     content: String,
 
-    #[xml("//metadata")]
+    #[xee(xml("//metadata"))]
     metadata: Option<String>,
 }
 
 #[derive(Extract, Debug, PartialEq)]
 struct ComplexDocument {
-    #[xpath("//id/text()")]
+    #[xee(xpath("//id/text()"))]
     id: String,
 
-    #[xml("//section")]
+    #[xee(xml("//section"))]
     sections: Vec<String>,
 }
 
 #[derive(Extract, Debug, PartialEq)]
 struct XmlWithAttributes {
-    #[xpath("//id/text()")]
+    #[xee(xpath("//id/text()"))]
     id: String,
 
-    #[xml("//element[@type='special']")]
+    #[xee(xml("//element[@type='special']"))]
     special_content: Option<String>,
 }
 
 #[derive(Extract, Debug, PartialEq)]
 struct SimpleXmlTest {
-    #[xpath("//id/text()")]
+    #[xee(xpath("//id/text()"))]
     id: String,
 
-    #[xml("//content")]
+    #[xee(xml("//content"))]
     content: String,
 }
 


### PR DESCRIPTION
## Summary
- update examples to prefix attributes (xpath, extract, etc.) with `xee`
- namespace all test attributes under `xee`

## Testing
- `cargo test --tests` *(fails: Unsupported attribute at struct level: Context)*

------
https://chatgpt.com/codex/tasks/task_b_688e35439c248323bebf997a47b91a69