### PR TITLE
refactor: update extract_one references

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     "#;
 
     let extractor = Extractor::new();
-    let entry: SimpleEntry = extractor.extract_one(xml)?;
+    let entry: SimpleEntry = extractor.extract_from_str(xml)?;
 
     println!("ID: {}", entry.id);
     println!("Title: {}", entry.title);
@@ -177,7 +177,7 @@ struct TaggedEntry {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let xml = r#"<entry><tags>alpha, beta, gamma</tags></entry>"#;
     let extractor = Extractor::new();
-    let entry: TaggedEntry = extractor.extract_one(xml)?;
+    let entry: TaggedEntry = extractor.extract_from_str(xml)?;
     assert_eq!(entry.tags.0, vec!["alpha", "beta", "gamma"]);
     Ok(())
 }
@@ -211,9 +211,9 @@ struct Entry {
 }
 
 // Parse Atom
-let atom: Entry = Extractor::default().extract_one(atom_xml)?;
+let atom: Entry = Extractor::default().extract_from_str(atom_xml)?;
 // Parse NLM using the named extraction
-let nlm: Entry = Extractor::named("nlm").extract_one(nlm_xml)?;
+let nlm: Entry = Extractor::named("nlm").extract_from_str(nlm_xml)?;
 ```
 
 This mechanism works for other struct-level attributes like `context` and

--- a/examples/01_basic_extraction.rs
+++ b/examples/01_basic_extraction.rs
@@ -53,7 +53,7 @@ fn main() {
     "#;
 
     let extractor = Extractor::new();
-    let person: Person = extractor.extract_one(person_xml).unwrap();
+    let person: Person = extractor.extract_from_str(person_xml).unwrap();
 
     println!("Person extracted:");
     println!("  Name: {}", person.name);
@@ -83,7 +83,7 @@ fn main() {
         </company>
     "#;
 
-    let company: Company = extractor.extract_one(company_xml).unwrap();
+    let company: Company = extractor.extract_from_str(company_xml).unwrap();
 
     println!("Company extracted:");
     println!("  ID: {}", company.id);
@@ -103,7 +103,7 @@ fn main() {
         </person>
     "#;
 
-    let person2: Person = extractor.extract_one(person_without_email).unwrap();
+    let person2: Person = extractor.extract_from_str(person_without_email).unwrap();
 
     println!("Person without email:");
     println!("  Name: {}", person2.name);

--- a/examples/02_named_extractions.rs
+++ b/examples/02_named_extractions.rs
@@ -42,7 +42,7 @@ fn main() {
     "#;
 
     let extractor = Extractor::new(); // or Extractor::default()
-    let entry: Entry = extractor.extract_one(atom_xml).unwrap();
+    let entry: Entry = extractor.extract_from_str(atom_xml).unwrap();
 
     println!("Default Atom extraction:");
     println!("  ID: {}", entry.id);
@@ -64,7 +64,7 @@ fn main() {
     "#;
 
     let extractor = Extractor::named("foo");
-    let entry: Entry = extractor.extract_one(nlm_xml).unwrap();
+    let entry: Entry = extractor.extract_from_str(nlm_xml).unwrap();
 
     println!("Named NLM extraction:");
     println!("  ID: {}", entry.id);
@@ -86,7 +86,7 @@ fn main() {
     "#;
 
     let extractor = Extractor::named("bar");
-    let entry: Entry = extractor.extract_one(context_xml).unwrap();
+    let entry: Entry = extractor.extract_from_str(context_xml).unwrap();
 
     println!("Context-based extraction:");
     println!("  ID: {}", entry.id);
@@ -103,7 +103,7 @@ fn main() {
     "#;
 
     let extractor = Extractor::named("foo");
-    let result = extractor.extract_one::<Entry>(wrong_xml);
+    let result = extractor.extract_from_str::<Entry>(wrong_xml);
     
     println!("Error handling for incompatible XML:");
     match result {
@@ -123,7 +123,7 @@ fn main() {
     "#;
 
     let extractor = Extractor::default(); // explicitly use default
-    let entry: Entry = extractor.extract_one(atom_xml_2).unwrap();
+    let entry: Entry = extractor.extract_from_str(atom_xml_2).unwrap();
 
     println!("Default extraction (explicit):");
     println!("  ID: {}", entry.id);
@@ -141,7 +141,7 @@ fn main() {
     "#;
 
     let extractor = Extractor::named("foo");
-    let entry: Entry = extractor.extract_one(nlm_xml_2).unwrap();
+    let entry: Entry = extractor.extract_from_str(nlm_xml_2).unwrap();
 
     println!("Named extraction with missing optional field:");
     println!("  ID: {}", entry.id);

--- a/examples/03_custom_extract_value.rs
+++ b/examples/03_custom_extract_value.rs
@@ -160,7 +160,7 @@ fn main() {
     "#;
 
     let extractor = Extractor::new();
-    let product: Product = extractor.extract_one(product_xml).unwrap();
+    let product: Product = extractor.extract_from_str(product_xml).unwrap();
 
     println!("Product with custom ExtractValue types:");
     println!("  Name: {}", product.name);
@@ -179,7 +179,7 @@ fn main() {
         </store>
     "#;
 
-    let store: Store = extractor.extract_one(store_xml).unwrap();
+    let store: Store = extractor.extract_from_str(store_xml).unwrap();
 
     println!("Store with custom ExtractValue types:");
     println!("  ID: {}", store.id);
@@ -197,7 +197,7 @@ fn main() {
         </product>
     "#;
 
-    let product: Product = extractor.extract_one(minimal_xml).unwrap();
+    let product: Product = extractor.extract_from_str(minimal_xml).unwrap();
 
     println!("Product with missing optional fields:");
     println!("  Name: {}", product.name);
@@ -216,7 +216,7 @@ fn main() {
         </product>
     "#;
 
-    let product: Product = extractor.extract_one(invalid_csv_xml).unwrap();
+    let product: Product = extractor.extract_from_str(invalid_csv_xml).unwrap();
 
     println!("Product with empty CSV (filtered out):");
     println!("  Name: {}", product.name);
@@ -234,7 +234,7 @@ fn main() {
         </product>
     "#;
 
-    let result = extractor.extract_one::<Product>(invalid_coords_xml);
+    let result = extractor.extract_from_str::<Product>(invalid_coords_xml);
     
     println!("Error handling for invalid coordinates:");
     match result {
@@ -252,7 +252,7 @@ fn main() {
         </product>
     "#;
 
-    let result = extractor.extract_one::<Product>(invalid_date_xml);
+    let result = extractor.extract_from_str::<Product>(invalid_date_xml);
     
     println!("Error handling for invalid date range:");
     match result {
@@ -269,7 +269,7 @@ fn main() {
         </product>
     "#;
 
-    let product: Product = extractor.extract_one(complex_csv_xml).unwrap();
+    let product: Product = extractor.extract_from_str(complex_csv_xml).unwrap();
 
     println!("Complex CSV with various whitespace:");
     println!("  Name: {}", product.name);

--- a/examples/04_namespaces.rs
+++ b/examples/04_namespaces.rs
@@ -84,7 +84,7 @@ fn main() {
     "#;
 
     let extractor = Extractor::new();
-    let feed: AtomFeed = extractor.extract_one(atom_xml).unwrap();
+    let feed: AtomFeed = extractor.extract_from_str(atom_xml).unwrap();
 
     println!("Atom feed with namespaces:");
     println!("  Title: {}", feed.title);
@@ -112,7 +112,7 @@ fn main() {
         </rss>
     "#;
 
-    let feed: RSSFeed = extractor.extract_one(rss_xml).unwrap();
+    let feed: RSSFeed = extractor.extract_from_str(rss_xml).unwrap();
 
     println!("RSS feed with namespaces:");
     println!("  Title: {}", feed.title);
@@ -134,7 +134,7 @@ fn main() {
         </soap:Envelope>
     "#;
 
-    let message: SOAPMessage = extractor.extract_one(soap_xml).unwrap();
+    let message: SOAPMessage = extractor.extract_from_str(soap_xml).unwrap();
 
     println!("SOAP message with multiple namespaces:");
     println!("  Action: {}", message.action);
@@ -154,7 +154,7 @@ fn main() {
         </root>
     "#;
 
-    let data: DefaultNamespaceData = extractor.extract_one(default_ns_xml).unwrap();
+    let data: DefaultNamespaceData = extractor.extract_from_str(default_ns_xml).unwrap();
 
     println!("Data with default namespace:");
     println!("  Title: {}", data.title);
@@ -171,7 +171,7 @@ fn main() {
         </feed>
     "#;
 
-    let result = extractor.extract_one::<AtomFeed>(no_namespace_xml);
+    let result = extractor.extract_from_str::<AtomFeed>(no_namespace_xml);
     
     println!("Error handling for missing namespace:");
     match result {

--- a/examples/05_contexts.rs
+++ b/examples/05_contexts.rs
@@ -108,7 +108,7 @@ fn main() {
     "#;
 
     let extractor = Extractor::new();
-    let book: Book = extractor.extract_one(book_xml).unwrap();
+    let book: Book = extractor.extract_from_str(book_xml).unwrap();
 
     println!("Book with simple context:");
     println!("  ID: {}", book.id);
@@ -127,7 +127,7 @@ fn main() {
         </book>
     "#;
 
-    let book: FlexibleBook = extractor.extract_one(direct_book_xml).unwrap();
+    let book: FlexibleBook = extractor.extract_from_str(direct_book_xml).unwrap();
 
     println!("Flexible book (direct structure):");
     println!("  ID: {}", book.id);
@@ -146,7 +146,7 @@ fn main() {
         </library>
     "#;
 
-    let book: FlexibleBook = extractor.extract_one(library_book_xml).unwrap();
+    let book: FlexibleBook = extractor.extract_from_str(library_book_xml).unwrap();
 
     println!("Flexible book (library structure):");
     println!("  ID: {}", book.id);
@@ -173,7 +173,7 @@ fn main() {
         </feed>
     "#;
 
-    let entry: FirstEntry = extractor.extract_one(entries_xml).unwrap();
+    let entry: FirstEntry = extractor.extract_from_str(entries_xml).unwrap();
 
     println!("First entry with context:");
     println!("  ID: {}", entry.id);
@@ -199,7 +199,7 @@ fn main() {
         </catalog>
     "#;
 
-    let product: FirstProduct = extractor.extract_one(products_xml).unwrap();
+    let product: FirstProduct = extractor.extract_from_str(products_xml).unwrap();
 
     println!("First product with position context:");
     println!("  SKU: {}", product.sku);
@@ -230,7 +230,7 @@ fn main() {
         </users>
     "#;
 
-    let admin: AdminUser = extractor.extract_one(users_xml).unwrap();
+    let admin: AdminUser = extractor.extract_from_str(users_xml).unwrap();
 
     println!("Admin user with conditional context:");
     println!("  ID: {}", admin.id);

--- a/examples/06_nested_structs.rs
+++ b/examples/06_nested_structs.rs
@@ -147,7 +147,7 @@ fn main() {
     "#;
 
     let extractor = Extractor::new();
-    let book: Book = extractor.extract_one(book_xml).unwrap();
+    let book: Book = extractor.extract_from_str(book_xml).unwrap();
 
     println!("Book with nested structs:");
     println!("  ID: {}", book.id);
@@ -200,7 +200,7 @@ fn main() {
         </company>
     "#;
 
-    let company: Company = extractor.extract_one(company_xml).unwrap();
+    let company: Company = extractor.extract_from_str(company_xml).unwrap();
 
     println!("Company with nested departments:");
     println!("  ID: {}", company.id);
@@ -244,7 +244,7 @@ fn main() {
         </order>
     "#;
 
-    let order: Order = extractor.extract_one(order_xml).unwrap();
+    let order: Order = extractor.extract_from_str(order_xml).unwrap();
 
     println!("Order with nested items and customer:");
     println!("  Order ID: {}", order.order_id);

--- a/examples/07_raw_xml.rs
+++ b/examples/07_raw_xml.rs
@@ -93,7 +93,7 @@ fn main() {
     "#;
 
     let extractor = Extractor::new();
-    let data: RawXMLData = extractor.extract_one(basic_xml).unwrap();
+    let data: RawXMLData = extractor.extract_from_str(basic_xml).unwrap();
 
     println!("Basic raw XML extraction:");
     println!("  Title: {}", data.title);
@@ -131,7 +131,7 @@ fn main() {
         </page>
     "#;
 
-    let html_data: HTMLContent = extractor.extract_one(html_xml).unwrap();
+    let html_data: HTMLContent = extractor.extract_from_str(html_xml).unwrap();
 
     println!("HTML content extraction:");
     println!("  Title: {}", html_data.title);
@@ -172,7 +172,7 @@ fn main() {
         </config>
     "#;
 
-    let config: ConfigWithXML = extractor.extract_one(config_xml).unwrap();
+    let config: ConfigWithXML = extractor.extract_from_str(config_xml).unwrap();
 
     println!("Configuration with raw XML:");
     println!("  Name: {}", config.name);
@@ -222,7 +222,7 @@ fn main() {
         </document>
     "#;
 
-    let document: DocumentWithMixedContent = extractor.extract_one(document_xml).unwrap();
+    let document: DocumentWithMixedContent = extractor.extract_from_str(document_xml).unwrap();
 
     println!("Document with mixed content:");
     println!("  ID: {}", document.id);
@@ -243,7 +243,7 @@ fn main() {
         </article>
     "#;
 
-    let result = extractor.extract_one::<RawXMLData>(incomplete_xml);
+    let result = extractor.extract_from_str::<RawXMLData>(incomplete_xml);
     
     println!("Error handling for missing XML elements:");
     match result {

--- a/examples/08_binary_handling.rs
+++ b/examples/08_binary_handling.rs
@@ -77,7 +77,7 @@ fn main() {
     "#;
 
     let extractor = Extractor::new();
-    let data: Base64Data = extractor.extract_one(base64_xml).unwrap();
+    let data: Base64Data = extractor.extract_from_str(base64_xml).unwrap();
 
     println!("Base64 encoded binary data:");
     println!("  Data: {:?}", data.data);
@@ -99,7 +99,7 @@ fn main() {
         </root>
     "#;
 
-    let data: HexData = extractor.extract_one(hex_xml).unwrap();
+    let data: HexData = extractor.extract_from_str(hex_xml).unwrap();
 
     println!("Hex encoded binary data:");
     println!("  Data: {:?}", data.data);
@@ -121,7 +121,7 @@ fn main() {
         </root>
     "#;
 
-    let data: MixedBinaryData = extractor.extract_one(mixed_xml).unwrap();
+    let data: MixedBinaryData = extractor.extract_from_str(mixed_xml).unwrap();
 
     println!("Mixed binary data types:");
     println!("  Base64 field: {:?}", data.base64_field);
@@ -145,7 +145,7 @@ fn main() {
         </root>
     "#;
 
-    let data: BinaryWithMetadata = extractor.extract_one(metadata_xml).unwrap();
+    let data: BinaryWithMetadata = extractor.extract_from_str(metadata_xml).unwrap();
 
     println!("Binary data with metadata:");
     println!("  Name: {}", data.name);

--- a/tests/basic_extraction.rs
+++ b/tests/basic_extraction.rs
@@ -53,7 +53,7 @@ fn test_simple_extraction() {
     "#;
 
     let extractor = Extractor::new();
-    let result: SimpleStruct = extractor.extract_one(xml).unwrap();
+    let result: SimpleStruct = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
     assert_eq!(result.title, "Sample Title");
@@ -77,7 +77,7 @@ fn test_complex_extraction_with_vectors() {
     "#;
 
     let extractor = Extractor::new();
-    let result: ComplexStruct = extractor.extract_one(xml).unwrap();
+    let result: ComplexStruct = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "456");
     assert_eq!(result.title, "Complex Title");
@@ -99,7 +99,7 @@ fn test_nested_extraction() {
     "#;
 
     let extractor = Extractor::new();
-    let result: NestedStruct = extractor.extract_one(xml).unwrap();
+    let result: NestedStruct = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "789");
     assert_eq!(result.author_name, "John Doe");

--- a/tests/binary_extraction.rs
+++ b/tests/binary_extraction.rs
@@ -37,7 +37,7 @@ fn test_binary_extraction_base64() {
     "#;
 
     let extractor = Extractor::new();
-    let result: BinaryData = extractor.extract_one(xml).unwrap();
+    let result: BinaryData = extractor.extract_from_str(xml).unwrap();
 
     // "Hello World" in base64
     let expected_base64 = b"Hello World".to_vec();
@@ -60,7 +60,7 @@ fn test_binary_extraction_with_option() {
     "#;
 
     let extractor = Extractor::new();
-    let result: BinaryWithOption = extractor.extract_one(xml).unwrap();
+    let result: BinaryWithOption = extractor.extract_from_str(xml).unwrap();
 
     // "Hello" in base64
     let expected_optional = b"Hello".to_vec();
@@ -80,7 +80,7 @@ fn test_binary_extraction_missing_optional() {
     "#;
 
     let extractor = Extractor::new();
-    let result: BinaryWithOption = extractor.extract_one(xml).unwrap();
+    let result: BinaryWithOption = extractor.extract_from_str(xml).unwrap();
 
     // "Hello" in hex
     let expected_required = b"Hello".to_vec();
@@ -100,7 +100,7 @@ fn test_binary_extraction_invalid_data() {
     "#;
 
     let extractor = Extractor::new();
-    let result = extractor.extract_one::<BinaryData>(xml);
+    let result = extractor.extract_from_str::<BinaryData>(xml);
 
     // Should fail because the data is not valid base64
     assert!(result.is_err());
@@ -116,7 +116,7 @@ fn test_binary_extraction_empty_data() {
     "#;
 
     let extractor = Extractor::new();
-    let result: BinaryData = extractor.extract_one(xml).unwrap();
+    let result: BinaryData = extractor.extract_from_str(xml).unwrap();
 
     // Empty data should result in empty Vec<u8>
     assert_eq!(result.base64_data, Vec::<u8>::new());

--- a/tests/complex_scenarios.rs
+++ b/tests/complex_scenarios.rs
@@ -119,7 +119,7 @@ fn test_complex_book_with_metadata() {
     "#;
 
     let extractor = Extractor::new();
-    let book: Book = extractor.extract_one(xml).unwrap();
+    let book: Book = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(book.id, "B001");
     assert_eq!(book.title, "The Rust Programming Language");
@@ -170,7 +170,7 @@ fn test_library_with_complex_books() {
     "#;
 
     let extractor = Extractor::new();
-    let library: LibraryWithComplexBooks = extractor.extract_one(xml).unwrap();
+    let library: LibraryWithComplexBooks = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(library.name, "Tech Library");
     assert_eq!(library.location, Some("San Francisco".to_string()));
@@ -226,7 +226,7 @@ fn test_company_with_departments() {
     "#;
 
     let extractor = Extractor::new();
-    let company: CompanyWithDepartments = extractor.extract_one(xml).unwrap();
+    let company: CompanyWithDepartments = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(company.id, "C001");
     assert_eq!(company.name, "Tech Corp");
@@ -263,7 +263,7 @@ fn test_complex_scenario_without_variables() {
     "#;
 
     let extractor = Extractor::new();
-    let result: ConfigStruct = extractor.extract_one(xml).unwrap();
+    let result: ConfigStruct = extractor.extract_from_str(xml).unwrap();
     
     assert_eq!(result.base_url, "https://api.example.com");
     assert_eq!(result.version, "v1");

--- a/tests/context.rs
+++ b/tests/context.rs
@@ -51,7 +51,7 @@ fn test_context_only() {
     "#;
 
     let extractor = Extractor::new();
-    let result: ContextOnly = extractor.extract_one(xml).unwrap();
+    let result: ContextOnly = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
     assert_eq!(result.title, "Test Title");
@@ -74,7 +74,7 @@ fn test_book_with_context_conditional() {
     "#;
 
     let extractor = Extractor::new();
-    let book: Book = extractor.extract_one(xml).unwrap();
+    let book: Book = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(book.id, "B001");
     assert_eq!(book.title, "The Rust Programming Language");
@@ -95,7 +95,7 @@ fn test_book_without_optional_fields_in_context() {
     "#;
 
     let extractor = Extractor::new();
-    let book: Book = extractor.extract_one(xml).unwrap();
+    let book: Book = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(book.id, "B002");
     assert_eq!(book.title, "Programming Rust");
@@ -116,7 +116,7 @@ fn test_error_handling_invalid_xpath() {
     "#;
 
     let extractor = Extractor::new();
-    let result = extractor.extract_one::<ContextOnly>(xml);
+    let result = extractor.extract_from_str::<ContextOnly>(xml);
     
     // This should fail because the XML doesn't have title and author elements
     assert!(result.is_err());

--- a/tests/error_handling.rs
+++ b/tests/error_handling.rs
@@ -58,7 +58,7 @@ fn test_missing_required_field_error() {
     "#;
 
     let extractor = Extractor::new();
-    let result: Result<SimpleStruct, ExtractError> = extractor.extract_one(xml);
+    let result: Result<SimpleStruct, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
 }
@@ -74,7 +74,7 @@ fn test_invalid_xml_error() {
     "#;
 
     let extractor = Extractor::new();
-    let result: Result<SimpleStruct, ExtractError> = extractor.extract_one(xml);
+    let result: Result<SimpleStruct, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
 }
@@ -89,7 +89,7 @@ fn test_missing_required_field_error_with_nested() {
     "#;
 
     let extractor = Extractor::new();
-    let result: Result<SimpleStructWithNested, ExtractError> = extractor.extract_one(xml);
+    let result: Result<SimpleStructWithNested, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
 }
@@ -105,7 +105,7 @@ fn test_missing_nested_struct_error() {
     "#;
 
     let extractor = Extractor::new();
-    let result: Result<SimpleStructWithNested, ExtractError> = extractor.extract_one(xml);
+    let result: Result<SimpleStructWithNested, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
 }
@@ -124,7 +124,7 @@ fn test_missing_required_field_in_nested_struct() {
     "#;
 
     let extractor = Extractor::new();
-    let result: Result<SimpleStructWithNested, ExtractError> = extractor.extract_one(xml);
+    let result: Result<SimpleStructWithNested, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
 }
@@ -140,7 +140,7 @@ fn test_invalid_xpath_expression() {
 
     let extractor = Extractor::new();
     // This would fail if we had an invalid XPath expression
-    let result: Result<SimpleStruct, ExtractError> = extractor.extract_one(xml);
+    let result: Result<SimpleStruct, ExtractError> = extractor.extract_from_str(xml);
 
     // Should succeed with valid XML and XPath
     assert!(result.is_ok());
@@ -151,7 +151,7 @@ fn test_empty_xml_document() {
     let xml = "";
 
     let extractor = Extractor::new();
-    let result: Result<SimpleStruct, ExtractError> = extractor.extract_one(xml);
+    let result: Result<SimpleStruct, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
 }
@@ -161,7 +161,7 @@ fn test_xml_with_only_whitespace() {
     let xml = "   \n   \t   ";
 
     let extractor = Extractor::new();
-    let result: Result<SimpleStruct, ExtractError> = extractor.extract_one(xml);
+    let result: Result<SimpleStruct, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
 }
@@ -177,7 +177,7 @@ fn test_xml_with_malformed_tags() {
     "#;
 
     let extractor = Extractor::new();
-    let result: Result<SimpleStruct, ExtractError> = extractor.extract_one(xml);
+    let result: Result<SimpleStruct, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
 }
@@ -192,7 +192,7 @@ fn test_xml_with_invalid_characters() {
     "#;
 
     let extractor = Extractor::new();
-    let result: Result<SimpleStruct, ExtractError> = extractor.extract_one(xml);
+    let result: Result<SimpleStruct, ExtractError> = extractor.extract_from_str(xml);
 
     // This should fail due to invalid XML characters
     assert!(result.is_err());

--- a/tests/named_extractions.rs
+++ b/tests/named_extractions.rs
@@ -35,7 +35,7 @@ fn test_default_atom_extraction() {
         "#;
 
     let extractor = Extractor::default();
-    let entry: Entry = extractor.extract_one(xml).unwrap();
+    let entry: Entry = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(entry.id, "urn:uuid:12345678-1234-1234-1234-123456789abc");
     assert_eq!(entry.title, "Atom Title");
@@ -57,7 +57,7 @@ fn test_named_extraction_nlm() {
         "#;
 
     let extractor = Extractor::named("extract1");
-    let entry: Entry = extractor.extract_one(xml).unwrap();
+    let entry: Entry = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(entry.id, "abc123");
     assert_eq!(entry.title, "NLM Title");
@@ -79,7 +79,7 @@ fn test_context_extraction() {
         "#;
 
     let extractor = Extractor::named("extract2");
-    let entry: Entry = extractor.extract_one(xml).unwrap();
+    let entry: Entry = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(entry.id, "c456");
     assert_eq!(entry.title, "Context Title");

--- a/tests/namespaces.rs
+++ b/tests/namespaces.rs
@@ -153,7 +153,7 @@ fn test_namespace_only() {
     "#;
 
     let extractor = Extractor::new();
-    let result: NamespaceOnly = extractor.extract_one(xml).unwrap();
+    let result: NamespaceOnly = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
     assert_eq!(result.title, "Test Title");
@@ -175,7 +175,7 @@ fn test_default_namespace_only() {
     "#;
 
     let extractor = Extractor::new();
-    let result: DefaultNamespaceOnly = extractor.extract_one(xml).unwrap();
+    let result: DefaultNamespaceOnly = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
     assert_eq!(result.title, "Test Title");
@@ -196,7 +196,7 @@ fn test_namespace_and_context() {
     "#;
 
     let extractor = Extractor::new();
-    let result: NamespaceAndContext = extractor.extract_one(xml).unwrap();
+    let result: NamespaceAndContext = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
     assert_eq!(result.title, "Test Title");
@@ -218,7 +218,7 @@ fn test_default_namespace_and_context() {
     "#;
 
     let extractor = Extractor::new();
-    let result: DefaultNamespaceAndContext = extractor.extract_one(xml).unwrap();
+    let result: DefaultNamespaceAndContext = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
     assert_eq!(result.title, "Test Title");
@@ -239,7 +239,7 @@ fn test_default_and_prefixed_namespaces() {
     "#;
 
     let extractor = Extractor::new();
-    let result: DefaultAndPrefixedNamespaces = extractor.extract_one(xml).unwrap();
+    let result: DefaultAndPrefixedNamespaces = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
     assert_eq!(result.title, "Test Title");
@@ -260,7 +260,7 @@ fn test_all_combined() {
     "#;
 
     let extractor = Extractor::new();
-    let result: AllCombined = extractor.extract_one(xml).unwrap();
+    let result: AllCombined = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
     assert_eq!(result.title, "Test Title");
@@ -284,7 +284,7 @@ fn test_nested_structs_with_different_namespaces() {
     "#;
 
     let extractor = Extractor::new();
-    let result: ParentWithNamespaces = extractor.extract_one(xml).unwrap();
+    let result: ParentWithNamespaces = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
     assert_eq!(result.author.name, "Test Author");
@@ -306,7 +306,7 @@ fn test_nested_structs_with_default_namespaces() {
     "#;
 
     let extractor = Extractor::new();
-    let result: ParentWithDefaultNamespace = extractor.extract_one(xml).unwrap();
+    let result: ParentWithDefaultNamespace = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
     assert_eq!(result.author.name, "Test Author");
@@ -325,7 +325,7 @@ fn test_error_handling_missing_namespace() {
     "#;
 
     let extractor = Extractor::new();
-    let result = extractor.extract_one::<DefaultNamespaceOnly>(xml);
+    let result = extractor.extract_from_str::<DefaultNamespaceOnly>(xml);
     
     // This should fail because the XML doesn't have the default namespace
     assert!(result.is_err());

--- a/tests/nested_structs.rs
+++ b/tests/nested_structs.rs
@@ -101,7 +101,7 @@ fn test_book_extraction() {
     "#;
 
     let extractor = Extractor::new();
-    let book: Book = extractor.extract_one(xml).unwrap();
+    let book: Book = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(book.id, "B001");
     assert_eq!(book.title, "The Rust Programming Language");
@@ -122,7 +122,7 @@ fn test_book_without_optional_fields() {
     "#;
 
     let extractor = Extractor::new();
-    let book: Book = extractor.extract_one(xml).unwrap();
+    let book: Book = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(book.id, "B002");
     assert_eq!(book.title, "Programming Rust");
@@ -149,7 +149,7 @@ fn test_person_extraction() {
     "#;
 
     let extractor = Extractor::new();
-    let person: Person = extractor.extract_one(xml).unwrap();
+    let person: Person = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(person.id, "P001");
     assert_eq!(person.first_name, "John");
@@ -171,7 +171,7 @@ fn test_person_without_optional_fields() {
     "#;
 
     let extractor = Extractor::new();
-    let person: Person = extractor.extract_one(xml).unwrap();
+    let person: Person = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(person.id, "P002");
     assert_eq!(person.first_name, "Jane");
@@ -213,7 +213,7 @@ fn test_complex_nested_extraction() {
     "#;
 
     let extractor = Extractor::new();
-    let company: Company = extractor.extract_one(xml).unwrap();
+    let company: Company = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(company.id, "C001");
     assert_eq!(company.name, "Tech Corp");
@@ -236,7 +236,7 @@ fn test_standalone_book_extraction() {
     "#;
 
     let extractor = Extractor::new();
-    let book: Book = extractor.extract_one(xml).unwrap();
+    let book: Book = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(book.id, "B001");
     assert_eq!(book.title, "The Rust Programming Language");
@@ -266,7 +266,7 @@ fn test_child_book_in_library_context() {
     "#;
 
     let extractor = Extractor::new();
-    let library: Library = extractor.extract_one(xml).unwrap();
+    let library: Library = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(library.name, "My Library");
     assert_eq!(library.books.len(), 2);
@@ -290,7 +290,7 @@ fn test_nested_extraction_with_new_attributes() {
     "#;
 
     let extractor = Extractor::new();
-    let result: SimpleStruct = extractor.extract_one(xml).unwrap();
+    let result: SimpleStruct = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
     assert_eq!(result.title, "Test Title");
@@ -311,7 +311,7 @@ fn test_nested_extraction_with_missing_optional() {
     "#;
 
     let extractor = Extractor::new();
-    let result: SimpleStruct = extractor.extract_one(xml).unwrap();
+    let result: SimpleStruct = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
     assert_eq!(result.title, "Test Title");

--- a/tests/optional_fields.rs
+++ b/tests/optional_fields.rs
@@ -67,7 +67,7 @@ fn test_extraction_with_missing_optional_field() {
     "#;
 
     let extractor = Extractor::new();
-    let result: SimpleStruct = extractor.extract_one(xml).unwrap();
+    let result: SimpleStruct = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
     assert_eq!(result.title, "Sample Title");
@@ -86,7 +86,7 @@ fn test_nested_extraction_with_missing_optional() {
     "#;
 
     let extractor = Extractor::new();
-    let result: NestedStruct = extractor.extract_one(xml).unwrap();
+    let result: NestedStruct = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "789");
     assert_eq!(result.author_name, "Jane Smith");
@@ -104,7 +104,7 @@ fn test_book_without_optional_fields() {
     "#;
 
     let extractor = Extractor::new();
-    let book: Book = extractor.extract_one(xml).unwrap();
+    let book: Book = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(book.title, "Programming Rust");
     assert_eq!(book.author, "Jim Blandy");
@@ -124,7 +124,7 @@ fn test_person_without_optional_fields() {
     "#;
 
     let extractor = Extractor::new();
-    let person: Person = extractor.extract_one(xml).unwrap();
+    let person: Person = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(person.id, "P002");
     assert_eq!(person.first_name, "Jane");
@@ -172,7 +172,7 @@ fn test_person_with_optional_fields() {
     "#;
 
     let extractor = Extractor::new();
-    let person: Person = extractor.extract_one(xml).unwrap();
+    let person: Person = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(person.id, "P001");
     assert_eq!(person.first_name, "John");

--- a/tests/pretty_errors.rs
+++ b/tests/pretty_errors.rs
@@ -56,7 +56,7 @@ fn test_pretty_error_invalid_xml() {
     "#;
 
     let extractor = Extractor::new();
-    let result: Result<SimpleStruct, ExtractError> = extractor.extract_one(xml);
+    let result: Result<SimpleStruct, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
     let error = result.unwrap_err();
@@ -89,7 +89,7 @@ fn test_pretty_error_invalid_xpath() {
     }
 
     let extractor = Extractor::new();
-    let result: Result<InvalidXPathStruct, ExtractError> = extractor.extract_one(xml);
+    let result: Result<InvalidXPathStruct, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
     let error = result.unwrap_err();
@@ -113,7 +113,7 @@ fn test_pretty_error_with_span() {
     "#;
 
     let extractor = Extractor::new();
-    let result: Result<SimpleStruct, ExtractError> = extractor.extract_one(xml);
+    let result: Result<SimpleStruct, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
     let error = result.unwrap_err();
@@ -131,7 +131,7 @@ fn test_pretty_error_empty_xml() {
     let xml = "";
 
     let extractor = Extractor::new();
-    let result: Result<SimpleStruct, ExtractError> = extractor.extract_one(xml);
+    let result: Result<SimpleStruct, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
     let error = result.unwrap_err();
@@ -156,7 +156,7 @@ fn test_application_error_extract_value() {
     "#;
 
     let extractor = Extractor::new();
-    let result: Result<Book, ExtractError> = extractor.extract_one(xml);
+    let result: Result<Book, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
     let error = result.unwrap_err();
@@ -187,7 +187,7 @@ fn test_application_error_value_extraction() {
     "#;
 
     let extractor = Extractor::new();
-    let result: Result<ValueTestStruct, ExtractError> = extractor.extract_one(xml);
+    let result: Result<ValueTestStruct, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
     let error = result.unwrap_err();
@@ -218,7 +218,7 @@ fn test_application_error_extract_struct() {
     "#;
 
     let extractor = Extractor::new();
-    let result: Result<ExtractTestStruct, ExtractError> = extractor.extract_one(xml);
+    let result: Result<ExtractTestStruct, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
     let error = result.unwrap_err();
@@ -245,7 +245,7 @@ fn test_application_error_xml_serialization() {
     "#;
 
     let extractor = Extractor::new();
-    let result: Result<XmlTestStruct, ExtractError> = extractor.extract_one(xml);
+    let result: Result<XmlTestStruct, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
     let error = result.unwrap_err();
@@ -277,7 +277,7 @@ fn test_application_error_namespace() {
     }
 
     let extractor = Extractor::new();
-    let result: Result<NamespaceTestStruct, ExtractError> = extractor.extract_one(xml);
+    let result: Result<NamespaceTestStruct, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
     let error = result.unwrap_err();

--- a/tests/vectors.rs
+++ b/tests/vectors.rs
@@ -66,7 +66,7 @@ fn test_empty_vector_extraction() {
     "#;
 
     let extractor = Extractor::new();
-    let result: ComplexStruct = extractor.extract_one(xml).unwrap();
+    let result: ComplexStruct = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
     assert_eq!(result.title, "Title");
@@ -90,7 +90,7 @@ fn test_vector_with_multiple_items() {
     "#;
 
     let extractor = Extractor::new();
-    let result: ComplexStruct = extractor.extract_one(xml).unwrap();
+    let result: ComplexStruct = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "456");
     assert_eq!(result.title, "Complex Title");
@@ -112,7 +112,7 @@ fn test_book_with_multiple_genres() {
     "#;
 
     let extractor = Extractor::new();
-    let book: Book = extractor.extract_one(xml).unwrap();
+    let book: Book = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(book.title, "The Rust Programming Language");
     assert_eq!(book.author, "Steve Klabnik");
@@ -132,7 +132,7 @@ fn test_book_with_single_genre() {
     "#;
 
     let extractor = Extractor::new();
-    let book: Book = extractor.extract_one(xml).unwrap();
+    let book: Book = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(book.title, "Programming Rust");
     assert_eq!(book.author, "Jim Blandy");
@@ -151,7 +151,7 @@ fn test_empty_library() {
     "#;
 
     let extractor = Extractor::new();
-    let result: Library = extractor.extract_one(xml).unwrap();
+    let result: Library = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.name, "Empty Library");
     assert_eq!(result.books.len(), 0);
@@ -189,7 +189,7 @@ fn test_company_with_multiple_employees() {
     "#;
 
     let extractor = Extractor::new();
-    let company: Company = extractor.extract_one(xml).unwrap();
+    let company: Company = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(company.id, "C001");
     assert_eq!(company.name, "Tech Corp");

--- a/tests/xml_attributes.rs
+++ b/tests/xml_attributes.rs
@@ -60,7 +60,7 @@ fn test_xml_attribute_basic() {
     "#;
 
     let extractor = Extractor::new();
-    let result: DocumentWithXml = extractor.extract_one(xml).unwrap();
+    let result: DocumentWithXml = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
     assert_eq!(result.title, "Test Document");
@@ -89,7 +89,7 @@ fn test_xml_attribute_with_vectors() {
     "#;
 
     let extractor = Extractor::new();
-    let result: ComplexDocument = extractor.extract_one(xml).unwrap();
+    let result: ComplexDocument = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "456");
     assert_eq!(result.sections.len(), 2);
@@ -111,7 +111,7 @@ fn test_xml_attribute_with_optional() {
     "#;
 
     let extractor = Extractor::new();
-    let result: XmlWithAttributes = extractor.extract_one(xml).unwrap();
+    let result: XmlWithAttributes = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "789");
     assert!(result
@@ -130,7 +130,7 @@ fn test_xml_attribute_missing_optional() {
     "#;
 
     let extractor = Extractor::new();
-    let result: XmlWithAttributes = extractor.extract_one(xml).unwrap();
+    let result: XmlWithAttributes = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "789");
     assert_eq!(result.special_content, None);
@@ -146,7 +146,7 @@ fn test_xml_attribute_empty_vector() {
     "#;
 
     let extractor = Extractor::new();
-    let result: ComplexDocument = extractor.extract_one(xml).unwrap();
+    let result: ComplexDocument = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "999");
     assert_eq!(result.sections.len(), 0);
@@ -165,7 +165,7 @@ fn test_xml_attribute_simple() {
     "#;
 
     let extractor = Extractor::new();
-    let result: DocumentWithXml = extractor.extract_one(xml).unwrap();
+    let result: DocumentWithXml = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
     assert_eq!(result.title, "Test Document");
@@ -184,7 +184,7 @@ fn test_xml_attribute_simple_xpath() {
     "#;
 
     let extractor = Extractor::new();
-    let result: SimpleXmlTest = extractor.extract_one(xml).unwrap();
+    let result: SimpleXmlTest = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
     assert!(result.content.contains("<p>This is some content</p>"));


### PR DESCRIPTION
## Summary
- replace outdated `extract_one` calls with `extract_from_str`
- update docs, examples, and tests for the new API

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_688eac4339b08323b1f3b5722e80f545