### PR TITLE
Use Extractor::default instead of new

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ let xml = r#"
     </entry>
 "#;
 
-let extractor = Extractor::new();
+let extractor = Extractor::default();
 let entry: SimpleEntry = extractor.extract_from_str(xml).unwrap();
 ```
 
@@ -193,7 +193,7 @@ struct TaggedEntry {
 
 
 let xml = r#"<entry><tags>alpha, beta, gamma</tags></entry>"#;
-let extractor = Extractor::new();
+let extractor = Extractor::default();
 let entry: TaggedEntry = extractor.extract_from_str(xml).unwrap();
 assert_eq!(entry.tags.0, vec!["alpha", "beta", "gamma"]);
 
@@ -276,12 +276,12 @@ let mut documents = xee_xpath::Documents::new();
 let doc_handle = documents.add_string_without_uri(xml).unwrap();
 
 // Extract laptop data
-let laptop_data: ProductData = Extractor::new()
+let laptop_data: ProductData = Extractor::default()
     .bind_value("product_id", "P001")
     .extract_from_docs(&mut documents, &doc_handle).unwrap();
 
 // Extract paperclip data
-let paperclip_data: ProductData = Extractor::new()
+let paperclip_data: ProductData = Extractor::default()
     .bind_value("product_id", "P002")
     .extract_from_docs(&mut documents, &doc_handle).unwrap();
 ```

--- a/examples/01_basic_extraction.rs
+++ b/examples/01_basic_extraction.rs
@@ -52,7 +52,7 @@ fn main() {
         </person>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let person: Person = extractor.extract_from_str(person_xml).unwrap();
 
     println!("Person extracted:");

--- a/examples/02_named_extractions.rs
+++ b/examples/02_named_extractions.rs
@@ -41,7 +41,7 @@ fn main() {
         </entry>
     "#;
 
-    let extractor = Extractor::new(); // or Extractor::default()
+    let extractor = Extractor::default();
     let entry: Entry = extractor.extract_from_str(atom_xml).unwrap();
 
     println!("Default Atom extraction:");

--- a/examples/03_custom_extract_value.rs
+++ b/examples/03_custom_extract_value.rs
@@ -167,7 +167,7 @@ fn main() {
         </product>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let product: Product = extractor.extract_from_str(product_xml).unwrap();
 
     println!("Product with custom ExtractValue types:");

--- a/examples/04_namespaces.rs
+++ b/examples/04_namespaces.rs
@@ -83,7 +83,7 @@ fn main() {
         </feed>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let feed: AtomFeed = extractor.extract_from_str(atom_xml).unwrap();
 
     println!("Atom feed with namespaces:");

--- a/examples/05_contexts.rs
+++ b/examples/05_contexts.rs
@@ -107,7 +107,7 @@ fn main() {
         </library>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let book: Book = extractor.extract_from_str(book_xml).unwrap();
 
     println!("Book with simple context:");

--- a/examples/06_nested_structs.rs
+++ b/examples/06_nested_structs.rs
@@ -146,7 +146,7 @@ fn main() {
         </book>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let book: Book = extractor.extract_from_str(book_xml).unwrap();
 
     println!("Book with nested structs:");

--- a/examples/07_raw_xml.rs
+++ b/examples/07_raw_xml.rs
@@ -92,7 +92,7 @@ fn main() {
         </article>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let data: RawXMLData = extractor.extract_from_str(basic_xml).unwrap();
 
     println!("Basic raw XML extraction:");

--- a/examples/08_binary_handling.rs
+++ b/examples/08_binary_handling.rs
@@ -76,7 +76,7 @@ fn main() {
         </root>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let data: Base64Data = extractor.extract_from_str(base64_xml).unwrap();
 
     println!("Base64 encoded binary data:");

--- a/examples/09_multi_document_extraction.rs
+++ b/examples/09_multi_document_extraction.rs
@@ -95,7 +95,7 @@ fn main() {
         .unwrap();
 
     // Extract user data with cross-document permissions
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let user: UserWithPermissions = extractor
         .extract_from_docs(&mut documents, &user_doc)
         .unwrap();

--- a/examples/10_bound_variables.rs
+++ b/examples/10_bound_variables.rs
@@ -56,8 +56,8 @@ struct ConditionalData {
 fn main() {
     // Example 1: Basic variable binding
     println!("=== Example 1: Basic Variable Binding ===");
-    
-    let extractor1 = Extractor::new()
+
+    let extractor1 = Extractor::default()
         .bind_value("user_name", "Alice Johnson")
         .bind_value("user_age", 28)
         .bind_value("is_active", true)
@@ -74,7 +74,7 @@ fn main() {
 
     // Example 2: Variable binding with partial XPath expressions
     println!("=== Example 2: Partial XPath with Variables ===");
-    
+
     let product_xml = r#"
         <catalog>
             <product id="P001" category="electronics">
@@ -97,7 +97,7 @@ fn main() {
         </catalog>
     "#;
 
-    let extractor2 = Extractor::new()
+    let extractor2 = Extractor::default()
         .bind_value("product_id", "P001")
         .bind_value("spec_type", "cpu");
 
@@ -112,8 +112,8 @@ fn main() {
 
     // Example 3: Conditional logic with variables
     println!("=== Example 3: Conditional Logic with Variables ===");
-    
-    let extractor3 = Extractor::new()
+
+    let extractor3 = Extractor::default()
         .bind_value("user_id", "U123")
         .bind_value("is_admin", true)
         .bind_value("has_permission", false)
@@ -126,4 +126,4 @@ fn main() {
     println!("  Role: {}", conditional_data.role);
     println!("  Permission: {}", conditional_data.permission);
     println!("  Language: {}", conditional_data.default_language);
-} 
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,11 +75,6 @@ impl Default for Extractor {
 }
 
 impl Extractor {
-    /// Create a new extractor
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     pub fn named(name: &str) -> Self {
         Self {
             variables: std::collections::HashMap::new(),
@@ -112,7 +107,7 @@ impl Extractor {
     /// Example:
     /// ```rust
     /// use xee_extract::Extractor;
-    /// let extractor = Extractor::new().bind_value("name", "John Doe").bind_value("is_student", true);
+    /// let extractor = Extractor::default().bind_value("name", "John Doe").bind_value("is_student", true);
     /// ```
     pub fn bind_value<S: Into<String>, V: Into<Atomic>>(self, name: S, val: V) -> Self {
         let atomic: Atomic = val.into();

--- a/tests/basic_extraction.rs
+++ b/tests/basic_extraction.rs
@@ -52,7 +52,7 @@ fn test_simple_extraction() {
         </entry>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: SimpleStruct = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
@@ -76,7 +76,7 @@ fn test_complex_extraction_with_vectors() {
         </entry>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: ComplexStruct = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "456");
@@ -98,7 +98,7 @@ fn test_nested_extraction() {
         </entry>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: NestedStruct = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "789");

--- a/tests/binary_extraction.rs
+++ b/tests/binary_extraction.rs
@@ -36,7 +36,7 @@ fn test_binary_extraction_base64() {
         </root>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: BinaryData = extractor.extract_from_str(xml).unwrap();
 
     // "Hello World" in base64
@@ -59,7 +59,7 @@ fn test_binary_extraction_with_option() {
         </root>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: BinaryWithOption = extractor.extract_from_str(xml).unwrap();
 
     // "Hello" in base64
@@ -79,7 +79,7 @@ fn test_binary_extraction_missing_optional() {
         </root>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: BinaryWithOption = extractor.extract_from_str(xml).unwrap();
 
     // "Hello" in hex
@@ -99,7 +99,7 @@ fn test_binary_extraction_invalid_data() {
         </root>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result = extractor.extract_from_str::<BinaryData>(xml);
 
     // Should fail because the data is not valid base64
@@ -115,7 +115,7 @@ fn test_binary_extraction_empty_data() {
         </root>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: BinaryData = extractor.extract_from_str(xml).unwrap();
 
     // Empty data should result in empty Vec<u8>

--- a/tests/complex_scenarios.rs
+++ b/tests/complex_scenarios.rs
@@ -118,7 +118,7 @@ fn test_complex_book_with_metadata() {
         </book>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let book: Book = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(book.id, "B001");
@@ -175,7 +175,7 @@ fn test_library_with_complex_books() {
         </library>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let library: LibraryWithComplexBooks = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(library.name, "Tech Library");
@@ -234,7 +234,7 @@ fn test_company_with_departments() {
         </company>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let company: CompanyWithDepartments = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(company.id, "C001");
@@ -277,7 +277,7 @@ fn test_complex_scenario_without_variables() {
         </config>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: ConfigStruct = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.base_url, "https://api.example.com");

--- a/tests/context.rs
+++ b/tests/context.rs
@@ -50,7 +50,7 @@ fn test_context_only() {
         </feed>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: ContextOnly = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
@@ -73,7 +73,7 @@ fn test_book_with_context_conditional() {
         </book>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let book: Book = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(book.id, "B001");
@@ -94,7 +94,7 @@ fn test_book_without_optional_fields_in_context() {
         </book>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let book: Book = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(book.id, "B002");
@@ -115,7 +115,7 @@ fn test_error_handling_invalid_xpath() {
         </feed>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result = extractor.extract_from_str::<ContextOnly>(xml);
 
     // This should fail because the XML doesn't have title and author elements

--- a/tests/error_handling.rs
+++ b/tests/error_handling.rs
@@ -57,7 +57,7 @@ fn test_missing_required_field_error() {
         </entry>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: Result<SimpleStruct, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
@@ -73,7 +73,7 @@ fn test_invalid_xml_error() {
         </entry>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: Result<SimpleStruct, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
@@ -88,7 +88,7 @@ fn test_missing_required_field_error_with_nested() {
         </root>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: Result<SimpleStructWithNested, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
@@ -104,7 +104,7 @@ fn test_missing_nested_struct_error() {
         </root>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: Result<SimpleStructWithNested, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
@@ -123,7 +123,7 @@ fn test_missing_required_field_in_nested_struct() {
         </root>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: Result<SimpleStructWithNested, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
@@ -138,7 +138,7 @@ fn test_invalid_xpath_expression() {
         </entry>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     // This would fail if we had an invalid XPath expression
     let result: Result<SimpleStruct, ExtractError> = extractor.extract_from_str(xml);
 
@@ -150,7 +150,7 @@ fn test_invalid_xpath_expression() {
 fn test_empty_xml_document() {
     let xml = "";
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: Result<SimpleStruct, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
@@ -160,7 +160,7 @@ fn test_empty_xml_document() {
 fn test_xml_with_only_whitespace() {
     let xml = "   \n   \t   ";
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: Result<SimpleStruct, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
@@ -176,7 +176,7 @@ fn test_xml_with_malformed_tags() {
         </entry>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: Result<SimpleStruct, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
@@ -191,7 +191,7 @@ fn test_xml_with_invalid_characters() {
         </entry>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: Result<SimpleStruct, ExtractError> = extractor.extract_from_str(xml);
 
     // This should fail due to invalid XML characters

--- a/tests/multi_doc_extraction.rs
+++ b/tests/multi_doc_extraction.rs
@@ -185,7 +185,7 @@ fn test_simple_cross_document_extraction() {
         )
         .unwrap();
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: CrossDocumentUser = extractor
         .extract_from_docs(&mut documents, &user_doc)
         .unwrap();
@@ -227,7 +227,7 @@ fn test_simple_direct_cross_document_extraction() {
         )
         .unwrap();
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: SimpleCrossDocument = extractor
         .extract_from_docs(&mut documents, &user_doc)
         .unwrap();
@@ -277,7 +277,7 @@ fn test_product_catalog_with_inventory() {
         )
         .unwrap();
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: ProductWithInventory = extractor
         .extract_from_docs(&mut documents, &catalog_doc)
         .unwrap();
@@ -322,7 +322,7 @@ fn test_order_with_customer_info() {
         )
         .unwrap();
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: OrderWithCustomer = extractor
         .extract_from_docs(&mut documents, &order_doc)
         .unwrap();
@@ -374,7 +374,7 @@ fn test_library_book_with_availability() {
         )
         .unwrap();
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: LibraryBook = extractor
         .extract_from_docs(&mut documents, &books_doc)
         .unwrap();
@@ -472,7 +472,7 @@ fn test_multiple_documents_with_complex_relationships() {
         project_names: Vec<String>,
     }
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: DepartmentWithDetails = extractor
         .extract_from_docs(&mut documents, &dept_doc)
         .unwrap();
@@ -503,7 +503,7 @@ fn test_error_handling_for_missing_document() {
         )
         .unwrap();
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: Result<CrossDocumentUser, _> =
         extractor.extract_from_docs(&mut documents, &user_doc);
 
@@ -554,7 +554,7 @@ fn test_document_without_uri_cannot_be_accessed_via_doc() {
         cross_ref_name: String,
     }
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: Result<UserWithPermissions, _> =
         extractor.extract_from_docs(&mut documents, &user_doc);
 

--- a/tests/namespaces.rs
+++ b/tests/namespaces.rs
@@ -152,7 +152,7 @@ fn test_namespace_only() {
         </feed>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: NamespaceOnly = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
@@ -174,7 +174,7 @@ fn test_default_namespace_only() {
         </feed>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: DefaultNamespaceOnly = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
@@ -195,7 +195,7 @@ fn test_namespace_and_context() {
         </feed>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: NamespaceAndContext = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
@@ -217,7 +217,7 @@ fn test_default_namespace_and_context() {
         </feed>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: DefaultNamespaceAndContext = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
@@ -238,7 +238,7 @@ fn test_default_and_prefixed_namespaces() {
         </feed>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: DefaultAndPrefixedNamespaces = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
@@ -259,7 +259,7 @@ fn test_all_combined() {
         </feed>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: AllCombined = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
@@ -283,7 +283,7 @@ fn test_nested_structs_with_different_namespaces() {
         </feed>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: ParentWithNamespaces = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
@@ -305,7 +305,7 @@ fn test_nested_structs_with_default_namespaces() {
         </feed>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: ParentWithDefaultNamespace = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
@@ -324,7 +324,7 @@ fn test_error_handling_missing_namespace() {
         </feed>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result = extractor.extract_from_str::<DefaultNamespaceOnly>(xml);
 
     // This should fail because the XML doesn't have the default namespace

--- a/tests/nested_structs.rs
+++ b/tests/nested_structs.rs
@@ -100,7 +100,7 @@ fn test_book_extraction() {
         </book>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let book: Book = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(book.id, "B001");
@@ -121,7 +121,7 @@ fn test_book_without_optional_fields() {
         </book>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let book: Book = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(book.id, "B002");
@@ -148,7 +148,7 @@ fn test_person_extraction() {
         </person>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let person: Person = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(person.id, "P001");
@@ -170,7 +170,7 @@ fn test_person_without_optional_fields() {
         </person>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let person: Person = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(person.id, "P002");
@@ -212,7 +212,7 @@ fn test_complex_nested_extraction() {
         </company>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let company: Company = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(company.id, "C001");
@@ -235,7 +235,7 @@ fn test_standalone_book_extraction() {
         </book>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let book: Book = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(book.id, "B001");
@@ -265,7 +265,7 @@ fn test_child_book_in_library_context() {
         </library>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let library: Library = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(library.name, "My Library");
@@ -289,7 +289,7 @@ fn test_nested_extraction_with_new_attributes() {
         </root>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: SimpleStruct = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
@@ -310,7 +310,7 @@ fn test_nested_extraction_with_missing_optional() {
         </root>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: SimpleStruct = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");

--- a/tests/optional_fields.rs
+++ b/tests/optional_fields.rs
@@ -66,7 +66,7 @@ fn test_extraction_with_missing_optional_field() {
         </entry>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: SimpleStruct = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
@@ -85,7 +85,7 @@ fn test_nested_extraction_with_missing_optional() {
         </entry>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: NestedStruct = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "789");
@@ -103,7 +103,7 @@ fn test_book_without_optional_fields() {
         </book>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let book: Book = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(book.title, "Programming Rust");
@@ -123,7 +123,7 @@ fn test_person_without_optional_fields() {
         </person>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let person: Person = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(person.id, "P002");
@@ -171,7 +171,7 @@ fn test_person_with_optional_fields() {
         </person>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let person: Person = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(person.id, "P001");

--- a/tests/pretty_errors.rs
+++ b/tests/pretty_errors.rs
@@ -55,7 +55,7 @@ fn test_pretty_error_invalid_xml() {
         </entry>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: Result<SimpleStruct, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
@@ -88,7 +88,7 @@ fn test_pretty_error_invalid_xpath() {
         _invalid: String,
     }
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: Result<InvalidXPathStruct, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
@@ -112,7 +112,7 @@ fn test_pretty_error_with_span() {
         </entry>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: Result<SimpleStruct, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
@@ -130,7 +130,7 @@ fn test_pretty_error_with_span() {
 fn test_pretty_error_empty_xml() {
     let xml = "";
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: Result<SimpleStruct, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
@@ -155,7 +155,7 @@ fn test_application_error_extract_value() {
         </entry>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: Result<Book, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
@@ -186,7 +186,7 @@ fn test_application_error_value_extraction() {
         </entry>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: Result<ValueTestStruct, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
@@ -217,7 +217,7 @@ fn test_application_error_extract_struct() {
         </entry>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: Result<ExtractTestStruct, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
@@ -244,7 +244,7 @@ fn test_application_error_xml_serialization() {
         </entry>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: Result<XmlTestStruct, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());
@@ -276,7 +276,7 @@ fn test_application_error_namespace() {
         _id: String,
     }
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: Result<NamespaceTestStruct, ExtractError> = extractor.extract_from_str(xml);
 
     assert!(result.is_err());

--- a/tests/variable_binding.rs
+++ b/tests/variable_binding.rs
@@ -148,7 +148,7 @@ struct OptionalVariableStruct {
 fn test_basic_variable_binding() {
     let xml = r#"<root></root>"#;
 
-    let extractor = Extractor::new()
+    let extractor = Extractor::default()
         .bind_value("user_name", "John Doe")
         .bind_value("user_age", 30)
         .bind_value("is_active", true)
@@ -187,7 +187,7 @@ fn test_partial_xpath_variable_binding() {
         </root>
     "#;
 
-    let extractor = Extractor::new()
+    let extractor = Extractor::default()
         .bind_value("user_id", "123")
         .bind_value("score_type", "math");
 
@@ -203,7 +203,7 @@ fn test_partial_xpath_variable_binding() {
 fn test_complex_variable_binding() {
     let xml = r#"<root></root>"#;
 
-    let extractor = Extractor::new()
+    let extractor = Extractor::default()
         .bind_value("company_name", "Tech Corp")
         .bind_value("employee_count", 500)
         .bind_value("revenue", 1000000.0)
@@ -249,7 +249,7 @@ fn test_complex_partial_xpath_variable_binding() {
         </root>
     "#;
 
-    let extractor = Extractor::new()
+    let extractor = Extractor::default()
         .bind_value("company_id", "C001")
         .bind_value("department", "engineering")
         .bind_value("fiscal_year", "2023")
@@ -268,7 +268,7 @@ fn test_complex_partial_xpath_variable_binding() {
 fn test_nested_variable_binding() {
     let xml = r#"<root></root>"#;
 
-    let extractor = Extractor::new()
+    let extractor = Extractor::default()
         .bind_value("api_base_url", "https://api.example.com")
         .bind_value("api_version", "v1.0")
         .bind_value("db_name", "production_db")
@@ -286,7 +286,7 @@ fn test_nested_variable_binding() {
 fn test_conditional_variable_binding() {
     let xml = r#"<root></root>"#;
 
-    let extractor = Extractor::new()
+    let extractor = Extractor::default()
         .bind_value("user_id", "user123")
         .bind_value("is_admin", true)
         .bind_value("has_permission", false)
@@ -324,7 +324,7 @@ fn test_conditional_partial_xpath_variable_binding() {
         </root>
     "#;
 
-    let extractor = Extractor::new()
+    let extractor = Extractor::default()
         .bind_value("user_id", "user123")
         .bind_value("permission_type", "read")
         .bind_value("default_language", "en")
@@ -342,7 +342,7 @@ fn test_conditional_partial_xpath_variable_binding() {
 fn test_optional_variable_binding() {
     let xml = r#"<root></root>"#;
 
-    let extractor = Extractor::new()
+    let extractor = Extractor::default()
         .bind_value("required_field", "always present")
         .bind_value("optional_field", "present")
         .bind_value("optional_number", 42)
@@ -360,7 +360,7 @@ fn test_optional_variable_binding() {
 fn test_different_data_types() {
     let xml = r#"<root></root>"#;
 
-    let extractor = Extractor::new()
+    let extractor = Extractor::default()
         .bind_value("user_name", "John Doe")
         .bind_value("user_age", 30i32)
         .bind_value("user_age_long", 30i64)
@@ -385,7 +385,7 @@ fn test_variable_binding_with_named_extraction() {
         </root>
     "#;
 
-    let extractor = Extractor::new()
+    let extractor = Extractor::default()
         .bind_value("prefix", "test_")
         .bind_value("suffix", "_value");
 
@@ -403,7 +403,7 @@ fn test_variable_binding_with_named_extraction() {
 fn test_variable_binding_error_handling() {
     let xml = r#"<root></root>"#;
 
-    let extractor = Extractor::new().bind_value("user_name", "John Doe");
+    let extractor = Extractor::default().bind_value("user_name", "John Doe");
     // Missing required variables
 
     let result = extractor.extract_from_str::<SimpleVariableStruct>(xml);
@@ -430,7 +430,7 @@ fn test_variable_binding_with_complex_xpath() {
         </root>
     "#;
 
-    let extractor = Extractor::new()
+    let extractor = Extractor::default()
         .bind_value("min_id", 2)
         .bind_value("max_id", 3)
         .bind_value("search_name", "Bob");
@@ -486,7 +486,7 @@ fn test_variable_binding_with_functions_and_partial_xpath() {
         </root>
     "#;
 
-    let extractor = Extractor::new()
+    let extractor = Extractor::default()
         .bind_value("product_id", "P001")
         .bind_value("spec_type", "cpu")
         .bind_value("min_rating", 4)
@@ -524,7 +524,7 @@ fn test_variable_binding_with_functions_and_partial_xpath() {
 fn test_variable_binding_with_string_operations() {
     let xml = r#"<root></root>"#;
 
-    let extractor = Extractor::new()
+    let extractor = Extractor::default()
         .bind_value("first_name", "John")
         .bind_value("last_name", "Doe")
         .bind_value("separator", " ")
@@ -552,7 +552,7 @@ fn test_variable_binding_with_string_operations() {
 fn test_variable_binding_with_numeric_operations() {
     let xml = r#"<root></root>"#;
 
-    let extractor = Extractor::new()
+    let extractor = Extractor::default()
         .bind_value("base_price", 100.0)
         .bind_value("tax_rate", 0.08)
         .bind_value("discount", 0.10)

--- a/tests/vectors.rs
+++ b/tests/vectors.rs
@@ -65,7 +65,7 @@ fn test_empty_vector_extraction() {
         </entry>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: ComplexStruct = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
@@ -89,7 +89,7 @@ fn test_vector_with_multiple_items() {
         </entry>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: ComplexStruct = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "456");
@@ -111,7 +111,7 @@ fn test_book_with_multiple_genres() {
         </book>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let book: Book = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(book.title, "The Rust Programming Language");
@@ -131,7 +131,7 @@ fn test_book_with_single_genre() {
         </book>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let book: Book = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(book.title, "Programming Rust");
@@ -150,7 +150,7 @@ fn test_empty_library() {
         </library>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: Library = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.name, "Empty Library");
@@ -188,7 +188,7 @@ fn test_company_with_multiple_employees() {
         </company>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let company: Company = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(company.id, "C001");

--- a/tests/xml_attributes.rs
+++ b/tests/xml_attributes.rs
@@ -59,7 +59,7 @@ fn test_xml_attribute_basic() {
         </document>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: DocumentWithXml = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
@@ -88,7 +88,7 @@ fn test_xml_attribute_with_vectors() {
         </document>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: ComplexDocument = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "456");
@@ -110,7 +110,7 @@ fn test_xml_attribute_with_optional() {
         </document>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: XmlWithAttributes = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "789");
@@ -129,7 +129,7 @@ fn test_xml_attribute_missing_optional() {
         </document>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: XmlWithAttributes = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "789");
@@ -145,7 +145,7 @@ fn test_xml_attribute_empty_vector() {
         </document>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: ComplexDocument = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "999");
@@ -164,7 +164,7 @@ fn test_xml_attribute_simple() {
         </document>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: DocumentWithXml = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");
@@ -183,7 +183,7 @@ fn test_xml_attribute_simple_xpath() {
         </document>
     "#;
 
-    let extractor = Extractor::new();
+    let extractor = Extractor::default();
     let result: SimpleXmlTest = extractor.extract_from_str(xml).unwrap();
 
     assert_eq!(result.id, "123");


### PR DESCRIPTION
## Summary
- remove `Extractor::new` constructor in favor of `Default`
- replace all `Extractor::new()` usages with `Extractor::default()` and update docs, tests, and examples

## Testing
- `cargo fmt -p xee-extract`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_688f5fef2dec83238dc3c10d8922fe9e