### PR TITLE
feat: demonstrate default attribute in examples

### DIFF
--- a/examples/01_basic_extraction.rs
+++ b/examples/01_basic_extraction.rs
@@ -5,6 +5,10 @@
 
 use xee_extract::{Extract, Extractor};
 
+fn default_nickname() -> String {
+    "No nickname".to_string()
+}
+
 /// A simple struct demonstrating basic field extraction
 #[derive(Extract)]
 struct Person {
@@ -14,10 +18,15 @@ struct Person {
     #[xee(xpath("//age"))]
     age: u32,
 
+    #[xee(xpath("//nickname"))]
+    #[xee(default("default_nickname"))]
+    nickname: String,
+
     #[xee(xpath("//email"))]
     email: Option<String>,
 
     #[xee(xpath("//hobbies/hobby"))]
+    #[xee(default)]
     hobbies: Vec<String>,
 }
 
@@ -43,6 +52,7 @@ fn main() {
         <person>
             <name>John Doe</name>
             <age>30</age>
+            <nickname>Johnny</nickname>
             <email>john@example.com</email>
             <hobbies>
                 <hobby>reading</hobby>
@@ -58,6 +68,7 @@ fn main() {
     println!("Person extracted:");
     println!("  Name: {}", person.name);
     println!("  Age: {}", person.age);
+    println!("  Nickname: {}", person.nickname);
     println!("  Email: {:?}", person.email);
     println!("  Hobbies: {:?}", person.hobbies);
     println!();
@@ -92,22 +103,20 @@ fn main() {
     println!("  City: {:?}", company.city);
     println!();
 
-    // Example 3: Handling missing optional fields
-    let person_without_email = r#"
+    // Example 3: Handling missing data with defaults
+    let person_with_defaults = r#"
         <person>
             <name>Jane Smith</name>
             <age>25</age>
-            <hobbies>
-                <hobby>painting</hobby>
-            </hobbies>
         </person>
     "#;
 
-    let person2: Person = extractor.extract_from_str(person_without_email).unwrap();
+    let person2: Person = extractor.extract_from_str(person_with_defaults).unwrap();
 
-    println!("Person without email:");
+    println!("Person with defaults:");
     println!("  Name: {}", person2.name);
     println!("  Age: {}", person2.age);
+    println!("  Nickname: {}", person2.nickname);
     println!("  Email: {:?}", person2.email);
     println!("  Hobbies: {:?}", person2.hobbies);
 }

--- a/examples/04_namespaces.rs
+++ b/examples/04_namespaces.rs
@@ -5,6 +5,10 @@
 
 use xee_extract::{Extract, Extractor};
 
+fn default_description() -> String {
+    "No description provided".to_string()
+}
+
 /// Struct for extracting Atom feed data with namespaces
 #[derive(Extract)]
 #[xee(ns(atom = "http://www.w3.org/2005/Atom"))]
@@ -58,7 +62,12 @@ struct DefaultNamespaceData {
     #[xee(xpath("//root/title"))]
     title: String,
 
+    #[xee(xpath("//root/description"))]
+    #[xee(default("default_description"))]
+    description: String,
+
     #[xee(xpath("//root/items/item"))]
+    #[xee(default)]
     items: Vec<String>,
 }
 
@@ -158,6 +167,7 @@ fn main() {
 
     println!("Data with default namespace:");
     println!("  Title: {}", data.title);
+    println!("  Description: {}", data.description);
     println!("  Items: {:?}", data.items);
     println!();
 }

--- a/examples/06_nested_structs.rs
+++ b/examples/06_nested_structs.rs
@@ -5,8 +5,9 @@
 
 use xee_extract::{Extract, Extractor};
 
-/// Nested struct for book metadata
-#[derive(Extract)]
+/// Nested struct for book metadata demonstrating struct-level defaults
+#[derive(Extract, Default)]
+#[xee(default)]
 struct BookMetadata {
     #[xee(xpath("isbn"))]
     isbn: String,
@@ -54,6 +55,7 @@ struct Book {
     author: Author,
 
     #[xee(extract("metadata"))]
+    #[xee(default)]
     metadata: BookMetadata,
 }
 
@@ -166,7 +168,25 @@ fn main() {
     println!("  Reviews: {:?}", book.metadata.reviews);
     println!();
 
-    // Example 2: Company with nested departments
+    // Example 2: Book without metadata demonstrating struct defaults
+    let book_without_metadata = r#"
+        <book id="B002" genre="fiction">
+            <title>Defaulted Book</title>
+            <price>9.99</price>
+            <author>
+                <name>Unknown</name>
+            </author>
+        </book>
+    "#;
+
+    let book2: Book = extractor.extract_from_str(book_without_metadata).unwrap();
+
+    println!("Book missing metadata uses defaults:");
+    println!("  ISBN: {}", book2.metadata.isbn);
+    println!("  Publisher: {:?}", book2.metadata.publisher);
+    println!();
+
+    // Example 3: Company with nested departments
     let company_xml = r#"
         <company id="C001">
             <name>Tech Corp</name>
@@ -222,7 +242,7 @@ fn main() {
     }
     println!();
 
-    // Example 3: Order with nested items and customer
+    // Example 4: Order with nested items and customer
     let order_xml = r#"
         <order order_id="ORD001">
             <order_date>2024-01-15</order_date>


### PR DESCRIPTION
## Summary
- showcase field-level defaults in basic extraction example
- include default values in namespace example
- add struct- and field-level defaults in nested structs example

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68924f49ff648323be8c888e2f819072