### PR TITLE
Make ExtractValue return ErrorType

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,12 +165,12 @@ Any type that implements `FromStr` works out of the box, but you can
 provide custom parsing by implementing this trait yourself.
 
 ```rust
-use xee_extract::{Extract, Extractor, ExtractValue, Error, Documents, Item};
+use xee_extract::{Extract, Extractor, ExtractValue, ErrorType, Documents, Item};
 
 struct CsvTags(Vec<String>);
 
 impl ExtractValue for CsvTags {
-    fn extract_value(documents: &mut Documents, item: &Item) -> Result<Self, Error> {
+    fn extract_value(documents: &mut Documents, item: &Item) -> Result<Self, ErrorType> {
         let s = item.string_value(documents.xot()).unwrap();
         Ok(CsvTags(
             s.split(',')

--- a/examples/03_custom_extract_value.rs
+++ b/examples/03_custom_extract_value.rs
@@ -3,7 +3,7 @@
 //! This example demonstrates how to implement custom ExtractValue for custom types
 //! that don't implement FromStr or need custom parsing logic.
 
-use xee_extract::{Documents, Error, Extract, ExtractValue, Extractor, Item};
+use xee_extract::{Documents, ErrorType, Extract, ExtractValue, Extractor, Item};
 
 /// Custom struct for CSV data that implements ExtractValue
 struct CSV {
@@ -18,7 +18,7 @@ impl CSV {
 
 /// Custom ExtractValue implementation for CSV
 impl ExtractValue for CSV {
-    fn extract_value(documents: &mut Documents, item: &Item) -> Result<Self, Error> {
+    fn extract_value(documents: &mut Documents, item: &Item) -> Result<Self, ErrorType> {
         let s = match item.string_value(documents.xot()) {
             Ok(s) => s,
             Err(_) => return Ok(CSV::new(Vec::new())), // Return empty CSV for any string value error
@@ -57,13 +57,13 @@ impl Coordinates {
 
 /// Custom ExtractValue implementation for Coordinates
 impl ExtractValue for Coordinates {
-    fn extract_value(documents: &mut Documents, item: &Item) -> Result<Self, Error> {
+    fn extract_value(documents: &mut Documents, item: &Item) -> Result<Self, ErrorType> {
         let s = item.string_value(documents.xot())?;
 
         // Parse "lat,lon" format
         let parts: Vec<&str> = s.split(',').collect();
         if parts.len() != 2 {
-            return Err(Error::DeserializationError(format!(
+            return Err(ErrorType::DeserializationError(format!(
                 "Invalid coordinates format: {}",
                 s
             )));
@@ -72,12 +72,12 @@ impl ExtractValue for Coordinates {
         let lat = parts[0]
             .trim()
             .parse::<f64>()
-            .map_err(|_| Error::DeserializationError(format!("Invalid latitude: {}", parts[0])))?;
+            .map_err(|_| ErrorType::DeserializationError(format!("Invalid latitude: {}", parts[0])))?;
 
         let lon = parts[1]
             .trim()
             .parse::<f64>()
-            .map_err(|_| Error::DeserializationError(format!("Invalid longitude: {}", parts[1])))?;
+            .map_err(|_| ErrorType::DeserializationError(format!("Invalid longitude: {}", parts[1])))?;
 
         Ok(Coordinates::new(lat, lon))
     }
@@ -100,13 +100,13 @@ impl DateRange {
 
 /// Custom ExtractValue implementation for DateRange
 impl ExtractValue for DateRange {
-    fn extract_value(documents: &mut Documents, item: &Item) -> Result<Self, Error> {
+    fn extract_value(documents: &mut Documents, item: &Item) -> Result<Self, ErrorType> {
         let s = item.string_value(documents.xot())?;
 
         // Parse "start to end" format
         let parts: Vec<&str> = s.split(" to ").collect();
         if parts.len() != 2 {
-            return Err(Error::DeserializationError(format!(
+            return Err(ErrorType::DeserializationError(format!(
                 "Invalid date range format: {}",
                 s
             )));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub use xee_extract_macros::Extract;
 mod error;
 
 // Re-export error types
-pub use error::{Error, ExtractError, FieldExtractionError, NoValueFoundError};
+pub use error::{Error, ErrorType, ExtractError, FieldExtractionError, NoValueFoundError};
 
 // Re-export commong xee-xpath types
 pub use xee_xpath::{Atomic, Documents, Item, Sequence};
@@ -47,7 +47,7 @@ pub trait Extract: Sized {
 /// Example:
 ///
 /// ```rust
-/// use xee_extract::{ExtractValue, Error, Documents, Item};
+/// use xee_extract::{ExtractValue, ErrorType, Documents, Item};
 ///
 /// struct Coordinates {
 ///     latitude: f64,
@@ -55,12 +55,12 @@ pub trait Extract: Sized {
 /// }
 ///
 /// impl ExtractValue for Coordinates {
-///     fn extract_value(documents: &mut Documents, item: &Item) -> Result<Self, Error> {
+///     fn extract_value(documents: &mut Documents, item: &Item) -> Result<Self, ErrorType> {
 ///         let s = item.string_value(documents.xot())?;
 ///         // Parse "lat,lon" format
 ///         let parts: Vec<&str> = s.split(',').collect();
 ///         if parts.len() != 2 {
-///             return Err(Error::DeserializationError(format!(
+///             return Err(ErrorType::DeserializationError(format!(
 ///                 "Invalid coordinates format: {}",
 ///                 s
 ///             )));
@@ -68,18 +68,18 @@ pub trait Extract: Sized {
 ///         let lat = parts[0]
 ///             .trim()
 ///             .parse::<f64>()
-///             .map_err(|_| Error::DeserializationError(format!("Invalid latitude: {}", parts[0])))?;
+///             .map_err(|_| ErrorType::DeserializationError(format!("Invalid latitude: {}", parts[0])))?;
 ///         let lon = parts[1]
 ///             .trim()
 ///             .parse::<f64>()
-///             .map_err(|_| Error::DeserializationError(format!("Invalid longitude: {}", parts[1])))?;
+///             .map_err(|_| ErrorType::DeserializationError(format!("Invalid longitude: {}", parts[1])))?;
 ///         Ok(Coordinates { latitude: lat, longitude: lon })
 ///     }
 /// }
 /// ```
 pub trait ExtractValue: Sized {
     /// Deserialize a value from an XPath item
-    fn extract_value(documents: &mut Documents, item: &Item) -> Result<Self, Error>;
+    fn extract_value(documents: &mut Documents, item: &Item) -> Result<Self, ErrorType>;
 }
 
 /// Default ExtractValue impl that punts to FromStr
@@ -88,10 +88,10 @@ where
     T: FromStr,
     T::Err: std::fmt::Display,
 {
-    fn extract_value(documents: &mut Documents, item: &Item) -> Result<Self, Error> {
+    fn extract_value(documents: &mut Documents, item: &Item) -> Result<Self, ErrorType> {
         let s = item.string_value(documents.xot())?;
         s.parse::<T>()
-            .map_err(|e| Error::DeserializationError(e.to_string()))
+            .map_err(|e| ErrorType::DeserializationError(e.to_string()))
     }
 }
 


### PR DESCRIPTION
## Summary
- introduce a new `ErrorType` for value extraction failures
- have `ExtractValue::extract_value` return `ErrorType` and re-export it
- update examples and docs to reflect the new error type

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_689256e253148323ac0eab081c04365c